### PR TITLE
Add on_crossing hook for cost-observer integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ venv/
 htmlcov/
 .chronicle/runs/
 *.sqlite
+.DS_Store
+**/.DS_Store

--- a/README.md
+++ b/README.md
@@ -89,6 +89,17 @@ result = run_agent(...)
 session.export_trace("fixtures/traces/incident-001/")
 ```
 
+### Cost / governance observers (`on_crossing`)
+
+Chronicle does **not** embed cost management. External systems (e.g. TokenOps) attach an observer:
+
+```python
+session = reset_session()
+session.on_crossing = my_observer  # (boundary_id, kind, input_state, result) -> None
+```
+
+Invoked after **LIVE** envelope record and **LIVE** cut-point capture. **Not** called on STUB replay. See `tests/test_cost_management_e2e.py` for an end-to-end fake ledger/budget pattern.
+
 ### How `@boundary` wraps your function
 
 Same decorator, two behaviors. The wrapper sits around your function — it does not replace your logic.
@@ -327,30 +338,28 @@ See `examples/langgraph_demo/agent.py`.
 
 ## Project Structure
 
+**Core vs examples:** only `chronicle/` is the installable library. Demos, screenshot assets, and interactive benches stay under `examples/`. Committed regression traces live in `fixtures/` (not package modules). See `examples/README.md`.
+
 ```
-chronicle/
-├── boundary.py         # @boundary decorator (record + replay + cut-point)
-├── session.py          # runtime session, trace export, stub/live modes
-├── execution_graph.py  # side graph builder (load/save/render)
-├── visualizer.py       # interactive HTML trace UI
-├── envelope/           # schema, capture, append-only store
-├── replay/             # ReplayPlan, ReplayInjector, structural assertions
-├── judge/              # Layer 2 rubric + LLM-as-judge runner
-├── instrumentation/    # OpenInference + LangGraph hooks
-├── cli.py
-fixtures/
-├── envelopes/          # single-step regression envelopes
-└── traces/             # multi-step trace graphs (graph.json + envelopes)
-examples/
-├── financial_incidents/ # refund, invoice, trade demos (run.py)
-├── deletion_agent/     # record → visualize → cut-point demo
-└── langgraph_demo/     # LangGraph node wrapping example
-scripts/
-├── run.py              # cross-platform runner (demo | test)
-├── demo.sh / .bat      # interactive demo
-├── test.sh / .bat      # pytest suite
-└── quickrun.sh / .bat  # alias for demo
-tests/
+chronicle/                 # installable package (pip install -e .)
+├── boundary.py            # @boundary decorator (record + replay + cut-point)
+├── session.py             # runtime session, on_crossing hook, stub/live modes
+├── execution_graph.py     # side graph builder (load/save/render)
+├── visualizer.py          # HTML trace UI (library + CLI)
+├── envelope/              # schema, capture, append-only store
+├── replay/                # ReplayPlan, ReplayInjector, structural assertions
+├── judge/                 # Layer 2 rubric + LLM-as-judge runner
+├── instrumentation/       # OpenInference + LangGraph hooks
+└── cli.py
+fixtures/                  # committed regression data (not library code)
+├── envelopes/             # single-step envelopes
+└── traces/                # multi-step graphs (graph.json + envelopes)
+examples/                  # demos / test benches (not imported by the package)
+├── financial_incidents/   # refund, invoice, trade demos
+├── deletion_agent/        # record → visualize → cut-point demo
+└── langgraph_demo/        # LangGraph node wrapping example
+scripts/                   # demo | test runners
+tests/                     # unit + e2e (incl. cost-management on_crossing)
 ```
 
 ## License

--- a/chronicle/__init__.py
+++ b/chronicle/__init__.py
@@ -13,7 +13,7 @@ from chronicle.envelope.schema import (
 )
 from chronicle.execution_graph import ExecutionGraph
 from chronicle.replay.plan import BoundaryMode, ReplayPlan
-from chronicle.session import get_session, reset_session
+from chronicle.session import ChronicleSession, SessionMode, get_session, reset_session
 
 __version__ = "0.1.0"
 
@@ -21,6 +21,7 @@ __all__ = [
     "ActionResult",
     "boundary",
     "BoundaryMode",
+    "ChronicleSession",
     "ContextMetadata",
     "Envelope",
     "ExecutionGraph",
@@ -30,6 +31,7 @@ __all__ = [
     "ReplayPlan",
     "reset_session",
     "SamplingParams",
+    "SessionMode",
     "ToolCall",
     "ToolSchema",
 ]

--- a/chronicle/boundary.py
+++ b/chronicle/boundary.py
@@ -83,6 +83,8 @@ def _record_call(session, fn, boundary_id, kind, args, kwargs, extract_input, ex
         result = extract_result(result)
     action_result = result_to_action_result(result, kind)
     session.record_envelope(boundary_id, kind, input_state, action_result)
+    if session.on_crossing is not None:
+        session.on_crossing(boundary_id, kind, input_state, result)
     return result
 
 
@@ -102,4 +104,6 @@ def _live_cutpoint_call(
     session.capture_live_result(boundary_id, invocation_index, result)
     session.next_invocation(boundary_id)
     session._replay_cursor[boundary_id] = invocation_index
+    if session.on_crossing is not None:
+        session.on_crossing(boundary_id, kind, input_state, result)
     return result

--- a/chronicle/session.py
+++ b/chronicle/session.py
@@ -9,6 +9,7 @@ from contextvars import ContextVar
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
+from collections.abc import Callable
 from typing import Any
 
 from chronicle.envelope.schema import (
@@ -47,6 +48,9 @@ class ChronicleSession:
     fixture_graph: ExecutionGraph | None = None  # type: ignore[name-defined]
     model_version: str = "demo-model"
     build_id: str = field(default_factory=lambda: os.environ.get("CHRONICLE_BUILD_ID", "dev-local"))
+    # Optional observer for boundary crossings (LIVE record + LIVE cut-point).
+    # Signature: (boundary_id, kind, input_state, result) -> None
+    on_crossing: Callable[[str, str, InputState, Any], None] | None = None
 
     _sequence: int = 0
     _invocation_counts: dict[str, int] = field(default_factory=dict)

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,15 @@
+# Chronicle examples
+
+Demos and test benches live here — **not** in the installable `chronicle` package.
+
+| Path | Purpose |
+|------|---------|
+| `deletion_agent/` | Record → visualize → cut-point replay demo |
+| `financial_incidents/` | Refund / invoice / trade incident demos (+ screenshot assets) |
+| `langgraph_demo/` | Optional LangGraph node-wrapping example |
+
+**Core library** (importable): `chronicle/` — `@boundary`, session, envelopes, replay, judge, CLI, visualizer API.
+
+**Regression fixtures** (committed traces/envelopes): `fixtures/` — used by demos and pytest; not shipped as package code.
+
+**Integration point for external cost observers** (e.g. TokenOps): set `session.on_crossing` — see `tests/test_cost_management_e2e.py`. Chronicle does not import cost-management products.

--- a/tests/test_cost_management_e2e.py
+++ b/tests/test_cost_management_e2e.py
@@ -1,0 +1,275 @@
+"""E2E: ``on_crossing`` as the cost-management integration point.
+
+Chronicle stays agnostic of TokenOps (and any ledger). External cost observers
+plug in via ``ChronicleSession.on_crossing`` — the same hook TokenOps uses.
+These tests prove that contract with a tiny in-file fake ledger/governor.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from chronicle.boundary import boundary
+from chronicle.envelope.schema import InputState
+from chronicle.replay.plan import ReplayPlan
+from chronicle.session import reset_session
+
+
+# ---------------------------------------------------------------------------
+# Fake cost manager (test double only — not part of the chronicle package)
+# ---------------------------------------------------------------------------
+
+
+class BudgetExceeded(Exception):
+    """Raised by the fake governor when cumulative spend exceeds budget."""
+
+    def __init__(self, spend: float, budget: float, boundary_id: str):
+        self.spend = spend
+        self.budget = budget
+        self.boundary_id = boundary_id
+        super().__init__(
+            f"budget exceeded at {boundary_id!r}: spend={spend} > budget={budget}"
+        )
+
+
+@dataclass
+class CrossingSpend:
+    boundary_id: str
+    kind: str
+    cost: float
+    result: Any
+
+
+@dataclass
+class FakeCostManager:
+    """Minimal ledger + governor that observes ``@boundary`` crossings.
+
+    Models the TokenOps plug-in pattern: install ``on_crossing``, accumulate
+    spend, and signal halt/reject when a fake budget is exceeded.
+    """
+
+    budget: float
+    cost_by_boundary: dict[str, float] = field(default_factory=dict)
+    default_cost: float = 1.0
+    spend: float = 0.0
+    halted: bool = False
+    crossings: list[CrossingSpend] = field(default_factory=list)
+
+    def cost_for(self, boundary_id: str) -> float:
+        return self.cost_by_boundary.get(boundary_id, self.default_cost)
+
+    def on_crossing(
+        self,
+        boundary_id: str,
+        kind: str,
+        input_state: InputState,
+        result: Any,
+    ) -> None:
+        if self.halted:
+            raise BudgetExceeded(self.spend, self.budget, boundary_id)
+
+        cost = self.cost_for(boundary_id)
+        self.spend += cost
+        self.crossings.append(
+            CrossingSpend(boundary_id=boundary_id, kind=kind, cost=cost, result=result)
+        )
+        if self.spend > self.budget:
+            self.halted = True
+            raise BudgetExceeded(self.spend, self.budget, boundary_id)
+
+
+@boundary("search", kind="tool")
+def search(query: str) -> dict:
+    return {"status": "ok", "hits": [query], "tokens": 10}
+
+
+@boundary("summarize", kind="tool")
+def summarize(text: str) -> dict:
+    return {"status": "ok", "summary": text[:20], "tokens": 25}
+
+
+@boundary("expensive_call", kind="tool")
+def expensive_call(label: str) -> dict:
+    return {"status": "ok", "label": label, "tokens": 100}
+
+
+# ---------------------------------------------------------------------------
+# E2E scenarios
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.layer1
+def test_e2e_observer_records_spend_and_envelopes():
+    """LIVE record: envelopes written AND cost observer runs for each crossing."""
+    session = reset_session()
+    session.enable_live()
+    session.begin_trace("cost-e2e-record")
+
+    manager = FakeCostManager(
+        budget=100.0,
+        cost_by_boundary={"search": 10.0, "summarize": 25.0},
+    )
+    session.on_crossing = manager.on_crossing
+
+    assert search("pricing")["hits"] == ["pricing"]
+    assert summarize("long agent output")["status"] == "ok"
+
+    assert len(session._recorded_envelopes) == 2
+    assert [e.node_id for e in session._recorded_envelopes] == ["search", "summarize"]
+    assert len(manager.crossings) == 2
+    assert manager.spend == 35.0
+    assert manager.halted is False
+    assert manager.crossings[0].boundary_id == "search"
+    assert manager.crossings[0].cost == 10.0
+    assert manager.crossings[1].boundary_id == "summarize"
+    assert manager.crossings[1].cost == 25.0
+
+
+@pytest.mark.layer1
+def test_e2e_budget_exceeded_signals_halt():
+    """When spend exceeds budget, the handler raises and sets halted."""
+    session = reset_session()
+    session.enable_live()
+    session.begin_trace("cost-e2e-halt")
+
+    manager = FakeCostManager(budget=15.0, cost_by_boundary={"search": 10.0})
+    session.on_crossing = manager.on_crossing
+
+    search("first")  # spend=10, under budget
+    with pytest.raises(BudgetExceeded) as exc_info:
+        search("second")  # spend=20 > 15
+
+    err = exc_info.value
+    assert err.boundary_id == "search"
+    assert err.spend == 20.0
+    assert err.budget == 15.0
+    assert manager.halted is True
+    # Envelope for the crossing that tipped the budget is still recorded
+    # (on_crossing runs after LIVE record — observer reacts, does not undo).
+    assert len(session._recorded_envelopes) == 2
+    assert len(manager.crossings) == 2
+
+
+@pytest.mark.layer1
+def test_e2e_halted_rejects_subsequent_crossings():
+    """Once halted, further crossings are rejected without adding spend."""
+    session = reset_session()
+    session.enable_live()
+    session.begin_trace("cost-e2e-reject")
+
+    manager = FakeCostManager(
+        budget=5.0,
+        cost_by_boundary={"expensive_call": 10.0, "search": 1.0},
+    )
+    session.on_crossing = manager.on_crossing
+
+    with pytest.raises(BudgetExceeded):
+        expensive_call("blow-budget")
+
+    assert manager.halted is True
+    spend_after_halt = manager.spend
+
+    with pytest.raises(BudgetExceeded):
+        search("should-reject")
+
+    assert manager.spend == spend_after_halt
+    # search still executed + recorded before on_crossing rejected
+    assert len(session._recorded_envelopes) == 2
+    assert session._recorded_envelopes[-1].node_id == "search"
+
+
+@pytest.mark.layer1
+def test_e2e_stub_replay_does_not_call_on_crossing(tmp_path):
+    """STUB replay returns fixtures without invoking the cost observer."""
+    session = reset_session()
+    session.enable_live()
+    session.begin_trace("cost-e2e-fixture")
+    search("fixture-query")
+    summarize("fixture-text")
+    trace_dir = tmp_path / "trace"
+    session.export_trace(trace_dir)
+
+    session = reset_session()
+    session.load_trace(trace_dir)
+    session.enable_replay(ReplayPlan().stub("search", 1).stub("summarize", 1))
+
+    manager = FakeCostManager(budget=100.0, default_cost=50.0)
+    session.on_crossing = manager.on_crossing
+
+    out = search("ignored")
+    out2 = summarize("ignored")
+
+    assert out["hits"] == ["fixture-query"]
+    assert out2["summary"] == "fixture-text"[:20]
+    assert manager.crossings == []
+    assert manager.spend == 0.0
+    assert manager.halted is False
+
+
+@pytest.mark.layer1
+def test_e2e_live_cutpoint_still_observes_cost(tmp_path):
+    """LIVE cut-point executes the tool and still bills the observer."""
+    session = reset_session()
+    session.enable_live()
+    search("fixture")
+    trace_dir = tmp_path / "trace"
+    session.export_trace(trace_dir)
+
+    session = reset_session()
+    session.load_trace(trace_dir)
+    session.enable_replay(ReplayPlan().live("search", 1))
+
+    manager = FakeCostManager(budget=100.0, cost_by_boundary={"search": 7.5})
+    session.on_crossing = manager.on_crossing
+
+    out = search("cutpoint-query")
+    assert out["hits"] == ["cutpoint-query"]
+    assert len(manager.crossings) == 1
+    assert manager.spend == 7.5
+    assert session.captured_result("search", 1) == out
+
+
+@pytest.mark.layer1
+def test_e2e_multi_crossing_cumulative_spend():
+    """Several distinct boundaries accumulate spend until the budget trips."""
+    session = reset_session()
+    session.enable_live()
+    session.begin_trace("cost-e2e-cumulative")
+
+    manager = FakeCostManager(
+        budget=40.0,
+        cost_by_boundary={
+            "search": 10.0,
+            "summarize": 25.0,
+            "expensive_call": 100.0,
+        },
+    )
+    session.on_crossing = manager.on_crossing
+
+    search("a")  # 10
+    search("b")  # 20
+    with pytest.raises(BudgetExceeded) as exc_info:
+        summarize("c")  # 45 > 40
+
+    assert exc_info.value.spend == 45.0
+    assert manager.spend == 45.0
+    assert [c.boundary_id for c in manager.crossings] == [
+        "search",
+        "search",
+        "summarize",
+    ]
+    assert len(session._recorded_envelopes) == 3
+
+    # Subsequent expensive call is rejected while halted
+    with pytest.raises(BudgetExceeded):
+        expensive_call("nope")
+    assert manager.spend == 45.0
+    assert len(manager.crossings) == 3

--- a/tests/test_on_crossing.py
+++ b/tests/test_on_crossing.py
@@ -93,3 +93,28 @@ def test_on_crossing_none_is_noop():
     session.enable_live()
     assert session.on_crossing is None
     assert echo_tool("x")["value"] == "x"
+
+
+@pytest.mark.layer1
+def test_on_crossing_multiple_live_crossings():
+    session = reset_session()
+    session.enable_live()
+    crossings: list[str] = []
+    session.on_crossing = lambda bid, kind, inp, result: crossings.append(bid)
+
+    echo_tool("a")
+    echo_tool("b")
+    echo_tool("c")
+
+    assert crossings == ["echo_tool", "echo_tool", "echo_tool"]
+    assert len(session._recorded_envelopes) == 3
+
+
+@pytest.mark.layer1
+def test_reset_session_clears_on_crossing():
+    session = reset_session()
+    session.on_crossing = lambda *args: None
+    assert session.on_crossing is not None
+
+    session = reset_session()
+    assert session.on_crossing is None

--- a/tests/test_on_crossing.py
+++ b/tests/test_on_crossing.py
@@ -1,0 +1,95 @@
+"""Unit tests for ChronicleSession.on_crossing hook."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from chronicle.boundary import boundary
+from chronicle.envelope.schema import InputState
+from chronicle.replay.plan import ReplayPlan
+from chronicle.session import reset_session
+
+
+@boundary("echo_tool", kind="tool")
+def echo_tool(value: str) -> dict:
+    return {"status": "ok", "value": value}
+
+
+@pytest.mark.layer1
+def test_on_crossing_invoked_in_live_record():
+    session = reset_session()
+    session.enable_live()
+    crossings: list[tuple] = []
+
+    def hook(boundary_id, kind, input_state, result):
+        crossings.append((boundary_id, kind, input_state, result))
+
+    session.on_crossing = hook
+
+    out = echo_tool("hello")
+    assert out == {"status": "ok", "value": "hello"}
+    assert len(crossings) == 1
+    bid, kind, inp, result = crossings[0]
+    assert bid == "echo_tool"
+    assert kind == "tool"
+    assert isinstance(inp, InputState)
+    assert result == {"status": "ok", "value": "hello"}
+
+
+@pytest.mark.layer1
+def test_on_crossing_invoked_at_live_cutpoint(tmp_path):
+    # Record a fixture envelope first
+    session = reset_session()
+    session.enable_live()
+    echo_tool("fixture")
+    trace_dir = tmp_path / "trace"
+    session.export_trace(trace_dir)
+
+    # Replay with LIVE cut-point and hook
+    session = reset_session()
+    session.load_trace(trace_dir)
+    session.enable_replay(ReplayPlan().live("echo_tool", 1))
+    crossings: list[tuple] = []
+    session.on_crossing = lambda *args: crossings.append(args)
+
+    out = echo_tool("cutpoint")
+    assert out == {"status": "ok", "value": "cutpoint"}
+    assert len(crossings) == 1
+    bid, kind, inp, result = crossings[0]
+    assert bid == "echo_tool"
+    assert kind == "tool"
+    assert result["value"] == "cutpoint"
+    assert session.captured_result("echo_tool", 1) == result
+
+
+@pytest.mark.layer1
+def test_on_crossing_not_invoked_when_stubbed(tmp_path):
+    session = reset_session()
+    session.enable_live()
+    echo_tool("fixture")
+    trace_dir = tmp_path / "trace"
+    session.export_trace(trace_dir)
+
+    session = reset_session()
+    session.load_trace(trace_dir)
+    session.enable_replay(ReplayPlan().stub("echo_tool", 1))
+    crossings: list[tuple] = []
+    session.on_crossing = lambda *args: crossings.append(args)
+
+    out = echo_tool("ignored")
+    assert out["value"] == "fixture"  # stubbed from fixture
+    assert crossings == []
+
+
+@pytest.mark.layer1
+def test_on_crossing_none_is_noop():
+    session = reset_session()
+    session.enable_live()
+    assert session.on_crossing is None
+    assert echo_tool("x")["value"] == "x"


### PR DESCRIPTION
## Summary
- Add optional `ChronicleSession.on_crossing` hook so boundary observers can react at each crossing without changing core recording semantics.
- Prove the hook as the cost-management integration point with end-to-end tests (`test_cost_management_e2e`, `test_on_crossing`).
- Clarify core vs examples in docs (`examples/README.md`, README updates) so cost demos stay out of the library surface.

## Test plan
- [ ] Run full pytest suite (`pytest`)
- [ ] Confirm `tests/test_on_crossing.py` passes
- [ ] Confirm `tests/test_cost_management_e2e.py` passes
- [ ] Spot-check README / examples docs for core vs examples wording


Made with [Cursor](https://cursor.com)