### PR TITLE
Add CI + release workflows and fix packaging for PyPI

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,36 @@
+name: Bug report
+description: Something in Chronicle behaves incorrectly (recording, replay, cut-point, judge, CLI).
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and what you expected instead.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction
+      description: Minimal steps or a code snippet. If it involves a fixture, attach or paste the relevant envelope.
+      placeholder: |
+        1. Record with `@boundary(...)`
+        2. Replay with `ReplayPlan().stub(...).live(...)`
+        3. ...
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Chronicle version
+      description: Output of `pip show agent-chronicle` (or the commit SHA).
+    validations:
+      required: true
+  - type: input
+    id: python
+    attributes:
+      label: Python version
+      placeholder: "3.11"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & ideas
+    url: https://github.com/theagentplane/chronicle/discussions
+    about: For open-ended questions or design discussions, start a Discussion. Please open an issue or Discussion before large changes so we can align.
+  - name: Security vulnerability
+    url: https://github.com/theagentplane/chronicle/blob/main/SECURITY.md
+    about: Do not file public issues for security problems — follow SECURITY.md instead.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,25 @@
+name: Feature request
+description: Propose a new capability or improvement (framework support, replay ergonomics, judges, etc.).
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What are you trying to do that Chronicle makes hard or impossible today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What should Chronicle do? API sketches welcome.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches or workarounds you've tried.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+<!-- Keep PRs small and focused on one thing (see CONTRIBUTING.md). -->
+
+## Summary
+
+<!-- What does this change and why? -->
+
+## Related issue
+
+<!-- e.g. Closes #123 -->
+
+## Checklist
+
+- [ ] Tests added or updated, and `pytest -v` passes locally
+- [ ] `ruff check .` is clean
+- [ ] Docs / CHANGELOG updated if user-facing
+- [ ] If the Envelope schema changed: bumped at least a minor version and included a fixture migration path (see RELEASING.md)
+- [ ] Commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Cancel superseded runs on the same ref to save runner minutes.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install ruff
+        run: pip install "ruff>=0.6"
+      - name: Lint
+        run: ruff check .
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install (editable, with dev extras)
+        run: pip install -e ".[dev]"
+      - name: Run tests
+        # Layer 2 uses a mock judge, so the full suite runs without any API key.
+        run: pytest -v

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+
+# Publishing a GitHub Release triggers a build and upload to PyPI.
+# See RELEASING.md for the one-time PyPI Trusted Publisher setup.
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build sdist and wheel
+        run: |
+          pip install "build>=1.2"
+          python -m build
+      - name: Check metadata
+        run: |
+          pip install twine
+          twine check dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    # Trusted Publishing (OIDC) — no API tokens stored. Matches the `pypi`
+    # environment and `release.yml` workflow name configured on PyPI.
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/chronicle/cli.py
+++ b/chronicle/cli.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import sys
-from pathlib import Path
 
 import click
 

--- a/chronicle/envelope/store.py
+++ b/chronicle/envelope/store.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 from chronicle.envelope.schema import Envelope

--- a/chronicle/session.py
+++ b/chronicle/session.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import os
 import uuid
 from contextvars import ContextVar
@@ -10,7 +9,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from chronicle.envelope.schema import (
     ActionResult,
@@ -21,7 +20,10 @@ from chronicle.envelope.schema import (
     ToolCall,
 )
 from chronicle.envelope.store import EnvelopeStore
-from chronicle.replay.plan import BoundaryMode, ReplayPlan
+from chronicle.replay.plan import ReplayPlan
+
+if TYPE_CHECKING:
+    from chronicle.execution_graph import ExecutionGraph
 
 _envelope_stack: ContextVar[list[str]] = ContextVar("chronicle_envelope_stack", default=[])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ description = "Record-and-replay for agent decision graphs: reproduce a prod age
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
-license-files = ["LICENSE"]
+license-files = ["LICENSE.txt"]
 authors = [
     { name = "Tisha Chawla" },
     { name = "Susheem Koul" },
@@ -38,17 +38,39 @@ classifiers = [
     "Topic :: Software Development :: Testing",
     "Topic :: Software Development :: Quality Assurance",
 ]
+# Core runtime is intentionally lean: the envelope schema, @boundary recorder,
+# replay engine, and CLI only need pydantic + click. Tracing/framework/judge
+# integrations live in optional extras so a plain install stays small.
 dependencies = [
-    # TODO: pin the real runtime dependencies, e.g.:
-    # "openinference-instrumentation>=0.1",
-    # "arize-phoenix-otel>=0.6",
+    "pydantic>=2",
+    "click>=8",
 ]
 
 [project.optional-dependencies]
+# LangGraph node instrumentation (chronicle/instrumentation/langgraph.py).
+langgraph = [
+    "langgraph>=0.2",
+    "langchain-core>=0.3",
+    "openinference-instrumentation-langchain>=0.1",
+]
+# OpenTelemetry + Phoenix tracing export (chronicle/instrumentation/openinference.py).
+phoenix = [
+    "opentelemetry-api>=1.20",
+    "opentelemetry-sdk>=1.20",
+    "opentelemetry-exporter-otlp>=1.20",
+    "openinference-instrumentation>=0.1",
+    "openinference-semantic-conventions>=0.1",
+    "arize-phoenix>=4",
+]
+# Layer 2 LLM-as-judge (chronicle/judge/runner.py OpenAIJudgeClient).
+judge = [
+    "openai>=1",
+]
 dev = [
     "pytest>=8",
     "ruff>=0.6",
     "build>=1.2",
+    "agent-chronicle[langgraph,phoenix,judge]",
 ]
 
 [project.urls]
@@ -68,7 +90,13 @@ packages = ["chronicle"]
 [tool.ruff]
 line-length = 100
 
+[tool.ruff.lint]
+# Tests and examples intentionally tweak sys.path and keep illustrative unused
+# bindings, so scope those relaxations rather than loosening rules everywhere.
+per-file-ignores = { "tests/**" = ["E402", "F401", "F841"], "examples/**" = ["E402", "F401", "F841", "F541"] }
+
 [tool.pytest.ini_options]
 markers = [
     "layer1: deterministic structural replay (never calls the LLM)",
+    "layer2: LLM-as-judge evaluation (uses a mock judge in CI, no live API)",
 ]


### PR DESCRIPTION
## Summary

The repo already has strong OSS bones (license, CONTRIBUTING, SECURITY, CODE_OF_CONDUCT, RELEASING), but two promises weren't backed by anything runnable and the package couldn't actually be published. This makes them real.

### CI — `.github/workflows/ci.yml`
- `ruff` lint + `pytest` matrix on Python 3.10 / 3.11 / 3.12
- Full suite runs with **no API keys** (Layer 2 uses the mock judge). All 36 tests pass locally.

### Release — `.github/workflows/release.yml`
- `python -m build` + `twine check`, then **PyPI Trusted Publishing (OIDC)** on GitHub Release
- Matches `RELEASING.md` exactly: workflow filename `release.yml`, environment `pypi`, no stored tokens

### Packaging — `pyproject.toml`
- **Declared real runtime deps** (`pydantic`, `click`) instead of the `TODO` stub — previously `pip install agent-chronicle` produced a broken, unimportable package
- Moved `opentelemetry` / `openinference` / `langgraph` / `openai` into optional extras (`phoenix`, `langgraph`, `judge`); `dev` pulls them all in
- **Fixed `license-files`**: the glob `"LICENSE"` never matched the actual `LICENSE.txt`, so the license was being dropped from the wheel
- Registered the `layer2` pytest marker; scoped `ruff` relaxations to `tests/`/`examples/`

### Lint hygiene
- Removed dead imports in `cli.py`, `store.py`, `session.py`
- Resolved `ExecutionGraph` forward references via a `TYPE_CHECKING` import (drops two `F821`s)

### Community
- Issue forms (bug / feature) + PR template with a DCO sign-off reminder

## Verification
- `ruff check .` → clean
- `pytest -q` → **36 passed**
- `python -m build` + `twine check dist/*` → **PASSED** for both sdist and wheel

## Note / follow-up
Publishing still needs the **one-time PyPI pending-publisher + `pypi` GitHub Environment** setup described in `RELEASING.md` (can't be done from code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)