### PR TITLE
fix: capture real model version + sampling params on the @boundary path

### DIFF
--- a/chronicle/boundary.py
+++ b/chronicle/boundary.py
@@ -3,11 +3,17 @@
 from __future__ import annotations
 
 import functools
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import Any, TypeVar
 
 from chronicle.envelope.schema import InputState
-from chronicle.session import SessionMode, get_session, result_to_action_result
+from chronicle.session import (
+    SessionMode,
+    get_session,
+    model_version_from,
+    result_to_action_result,
+    sampling_params_from,
+)
 
 F = TypeVar("F", bound=Callable[..., Any])
 
@@ -18,6 +24,7 @@ def boundary(
     kind: str = "custom",
     extract_input: Callable[..., InputState] | None = None,
     extract_result: Callable[[Any], Any] | None = None,
+    extract_metadata: Callable[[Any], Mapping[str, Any]] | None = None,
 ) -> Callable[[F], F]:
     """
     Annotate a decision boundary for Chronicle record and replay.
@@ -25,6 +32,12 @@ def boundary(
     LIVE mode:     execute function, record envelope
     REPLAY + STUB: return fixture without executing
     REPLAY + LIVE: execute function (cut-point), capture input/result for assertions
+
+    extract_metadata lets a boundary surface the real model version and sampling
+    parameters it used (returned as a mapping) so the envelope pins what actually
+    ran. For ``kind="llm"`` these are also auto-detected from conventional keys on
+    the returned dict (``model``/``model_version``, ``temperature``, ``top_p``,
+    ``max_tokens``, ``seed``); the hook, when given, takes precedence.
     """
 
     def decorator(fn: F) -> F:
@@ -35,7 +48,7 @@ def boundary(
             if session.mode == SessionMode.LIVE:
                 return _record_call(
                     session, fn, boundary_id, kind, args, kwargs,
-                    extract_input, extract_result,
+                    extract_input, extract_result, extract_metadata,
                 )
 
             invocation_index = session._replay_cursor.get(boundary_id, 0) + 1
@@ -72,7 +85,7 @@ def _default_input_state(args: tuple, kwargs: dict) -> InputState:
     )
 
 
-def _record_call(session, fn, boundary_id, kind, args, kwargs, extract_input, extract_result):
+def _record_call(session, fn, boundary_id, kind, args, kwargs, extract_input, extract_result, extract_metadata):
     input_state = (
         extract_input(*args, **kwargs)
         if extract_input
@@ -82,10 +95,31 @@ def _record_call(session, fn, boundary_id, kind, args, kwargs, extract_input, ex
     if extract_result:
         result = extract_result(result)
     action_result = result_to_action_result(result, kind)
-    session.record_envelope(boundary_id, kind, input_state, action_result)
+    model_version, sampling_params = _call_metadata(result, kind, extract_metadata)
+    session.record_envelope(
+        boundary_id, kind, input_state, action_result,
+        model_version=model_version, sampling_params=sampling_params,
+    )
     if session.on_crossing is not None:
         session.on_crossing(boundary_id, kind, input_state, result)
     return result
+
+
+def _call_metadata(result, kind, extract_metadata):
+    """Capture the real model version and sampling params for this crossing.
+
+    Model metadata only applies to ``llm`` boundaries, so tool and router
+    results are not scraped for a stray ``model`` key. An explicit
+    extract_metadata hook always wins and works for any kind. Returns
+    ``(None, None)`` when nothing is available, letting record_envelope fall
+    back to the session default.
+    """
+    if extract_metadata is not None:
+        source = extract_metadata(result)
+        return model_version_from(source), sampling_params_from(source)
+    if kind == "llm":
+        return model_version_from(result), sampling_params_from(result)
+    return None, None
 
 
 def _live_cutpoint_call(

--- a/chronicle/session.py
+++ b/chronicle/session.py
@@ -2,15 +2,14 @@
 
 from __future__ import annotations
 
-import json
 import os
 import uuid
+from collections.abc import Callable, Mapping
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from chronicle.envelope.schema import (
     ActionResult,
@@ -19,9 +18,13 @@ from chronicle.envelope.schema import (
     InputState,
     SamplingParams,
     ToolCall,
+    ToolSchema,
 )
 from chronicle.envelope.store import EnvelopeStore
-from chronicle.replay.plan import BoundaryMode, ReplayPlan
+from chronicle.replay.plan import ReplayPlan
+
+if TYPE_CHECKING:
+    from chronicle.execution_graph import ExecutionGraph
 
 _envelope_stack: ContextVar[list[str]] = ContextVar("chronicle_envelope_stack", default=[])
 
@@ -46,7 +49,7 @@ class ChronicleSession:
     store: EnvelopeStore | None = None
     replay_plan: ReplayPlan = field(default_factory=ReplayPlan)
     fixture_graph: ExecutionGraph | None = None  # type: ignore[name-defined]
-    model_version: str = "demo-model"
+    model_version: str = "unknown"
     build_id: str = field(default_factory=lambda: os.environ.get("CHRONICLE_BUILD_ID", "dev-local"))
     # Optional observer for boundary crossings (LIVE record + LIVE cut-point).
     # Signature: (boundary_id, kind, input_state, result) -> None
@@ -124,6 +127,10 @@ class ChronicleSession:
         kind: str,
         input_state: InputState,
         action_result: ActionResult,
+        *,
+        model_version: str | None = None,
+        sampling_params: SamplingParams | None = None,
+        tool_schemas: list[ToolSchema] | None = None,
     ) -> Envelope:
         invocation_index = self.next_invocation(boundary_id)
         sequence = self.next_sequence()
@@ -137,9 +144,12 @@ class ChronicleSession:
             sequence=sequence,
             invocation_index=invocation_index,
             metadata=ContextMetadata(
-                model_version=self.model_version,
+                # Prefer what the call actually used; fall back to the session
+                # default only when the boundary surfaced no real metadata.
+                model_version=model_version or self.model_version,
                 build_id=self.build_id,
-                sampling_params=SamplingParams(),
+                sampling_params=sampling_params or SamplingParams(),
+                tool_schemas=tool_schemas or [],
                 framework="chronicle.boundary",
                 node_id=boundary_id,
                 trace_id=self.trace_id,
@@ -264,5 +274,62 @@ def result_to_action_result(result: Any, kind: str) -> ActionResult:
             tool_calls=tool_calls,
             completion=result.get("completion"),
             finish_reason=result.get("finish_reason"),
+            token_usage=_as_token_usage(result.get("token_usage") or result.get("usage")),
         )
     return ActionResult(completion=str(result), raw_response=result if isinstance(result, dict) else None)
+
+
+def _as_token_usage(source: Any) -> dict[str, int]:
+    """Coerce a usage mapping into the envelope's ``dict[str, int]`` shape.
+
+    LLM SDKs report usage under slightly different keys and occasionally as
+    floats, so keep only the integer counts and drop anything else rather than
+    fail validation on a stray value.
+    """
+    if not isinstance(source, Mapping):
+        return {}
+    usage: dict[str, int] = {}
+    for key, value in source.items():
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, int):
+            usage[str(key)] = value
+        elif isinstance(value, float) and value.is_integer():
+            usage[str(key)] = int(value)
+    return usage
+
+
+def sampling_params_from(source: Any) -> SamplingParams | None:
+    """Best-effort extraction of sampling parameters from a boundary result.
+
+    Recognizes either a nested ``sampling_params`` mapping or the flat keys
+    (temperature, top_p, max_tokens, seed) that common LLM SDKs return. Returns
+    ``None`` when nothing recognizable is present, so callers fall back to the
+    session/recorder default instead of recording empty parameters.
+    """
+    if not isinstance(source, Mapping):
+        return None
+    nested = source.get("sampling_params")
+    if isinstance(nested, Mapping):
+        source = nested
+    keys = ("temperature", "top_p", "max_tokens", "seed")
+    if not any(k in source for k in keys):
+        return None
+    return SamplingParams(
+        temperature=source.get("temperature"),
+        top_p=source.get("top_p"),
+        max_tokens=source.get("max_tokens"),
+        seed=source.get("seed"),
+    )
+
+
+def model_version_from(source: Any) -> str | None:
+    """Best-effort extraction of the resolved model version from a result.
+
+    Prefers an explicit ``model_version`` and falls back to ``model`` (what
+    most SDK responses echo back). Returns ``None`` when neither is present.
+    """
+    if not isinstance(source, Mapping):
+        return None
+    value = source.get("model_version") or source.get("model")
+    return str(value) if value else None

--- a/tests/test_metadata_capture.py
+++ b/tests/test_metadata_capture.py
@@ -1,0 +1,108 @@
+"""Model metadata capture on the @boundary record path.
+
+These pin the fidelity promise from the README's Envelope table: the recorded
+envelope should reflect the model version and sampling parameters the call
+actually used, not a session placeholder.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from chronicle import boundary, reset_session
+
+
+@pytest.mark.layer1
+def test_llm_boundary_captures_model_and_sampling():
+    @boundary("planner", kind="llm")
+    def planner(state: dict) -> dict:
+        return {
+            "completion": "ok",
+            "finish_reason": "stop",
+            "model": "gpt-4o-2024-08-06",
+            "temperature": 0.2,
+            "max_tokens": 256,
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+        }
+
+    session = reset_session()
+    session.begin_trace("t-meta")
+    planner({"messages": [{"role": "user", "content": "hi"}]})
+
+    env = session._recorded_envelopes[-1]
+    assert env.metadata.model_version == "gpt-4o-2024-08-06"
+    assert env.metadata.sampling_params.temperature == 0.2
+    assert env.metadata.sampling_params.max_tokens == 256
+    assert env.action_result.token_usage == {"input_tokens": 10, "output_tokens": 5}
+
+
+@pytest.mark.layer1
+def test_nested_sampling_params_are_captured():
+    @boundary("planner", kind="llm")
+    def planner(state: dict) -> dict:
+        return {
+            "completion": "ok",
+            "model_version": "claude-sonnet-4-6",
+            "sampling_params": {"temperature": 0.0, "top_p": 0.9, "seed": 7},
+        }
+
+    session = reset_session()
+    session.begin_trace("t-nested")
+    planner({"messages": []})
+
+    sp = session._recorded_envelopes[-1].metadata.sampling_params
+    assert (sp.temperature, sp.top_p, sp.seed) == (0.0, 0.9, 7)
+
+
+@pytest.mark.layer1
+def test_falls_back_to_session_default_when_unspecified():
+    @boundary("planner", kind="llm")
+    def planner(state: dict) -> dict:
+        return {"completion": "ok", "finish_reason": "stop"}
+
+    session = reset_session()
+    session.model_version = "claude-sonnet-4-6"  # user-pinned default
+    session.begin_trace("t-default")
+    planner({"messages": []})
+
+    assert session._recorded_envelopes[-1].metadata.model_version == "claude-sonnet-4-6"
+
+
+@pytest.mark.layer1
+def test_default_model_version_is_honest_placeholder():
+    # Never silently claim a fake pinned version like the old "demo-model".
+    assert reset_session().model_version == "unknown"
+
+
+@pytest.mark.layer1
+def test_tool_boundary_is_not_mislabeled_with_model():
+    # A tool result that happens to carry a "model" key must not become the
+    # envelope's model_version — only llm boundaries carry model metadata.
+    @boundary("lookup", kind="tool")
+    def lookup(path: str) -> dict:
+        return {"status": "ok", "model": "not-a-model-version"}
+
+    session = reset_session()
+    session.begin_trace("t-tool")
+    lookup("/x")
+
+    assert session._recorded_envelopes[-1].metadata.model_version == "unknown"
+
+
+@pytest.mark.layer1
+def test_extract_metadata_hook_overrides():
+    @boundary(
+        "planner",
+        kind="llm",
+        extract_metadata=lambda r: {"model_version": r["meta"]["m"], "temperature": 0.7},
+    )
+    def planner(state: dict) -> dict:
+        return {"completion": "ok", "meta": {"m": "gpt-4o-mini"}}
+
+    session = reset_session()
+    session.begin_trace("t-hook")
+    planner({"messages": []})
+
+    env = session._recorded_envelopes[-1]
+    assert env.metadata.model_version == "gpt-4o-mini"
+    assert env.metadata.sampling_params.temperature == 0.7


### PR DESCRIPTION
## The problem
The README's Envelope table promises **"pinned model version, sampling parameters."** But the primary `@boundary` record path hardcoded `model_version="demo-model"` and recorded **empty** `SamplingParams` (`session.py`), so the single most differentiated field on an envelope was never real unless you hand-wired an `EnvelopeRecorder`. That is the credibility gap a MAS dev notices in five minutes.

## The fix
- **Auto-capture for `kind="llm"`**: `@boundary` reads the model version and sampling params from conventional keys on the returned dict (`model` / `model_version`, `temperature`, `top_p`, `max_tokens`, `seed`) plus token usage (`usage` / `token_usage`).
- **`extract_metadata` hook**: any boundary can surface real metadata explicitly (a mapping); it takes precedence over auto-detection.
- **`record_envelope`** now accepts per-call `model_version` / `sampling_params` / `tool_schemas`, falling back to the session default only when the call surfaced nothing.
- **No mislabeling**: tool/router boundaries are not scraped for a stray `model` key.
- **Honest default**: `session.model_version` is now `"unknown"` instead of the fake `"demo-model"`.

Backward compatible: existing recorders and the `session.model_version` override still work; this only fills fields that were previously blank.

## Tests
New `tests/test_metadata_capture.py` (6 cases): flat + nested sampling capture, token usage, session-default fallback, honest default, tool non-mislabel, and the hook override. **Full suite: 42 passed**, `ruff` clean.

## Note
Touches `session.py` imports, so expect a trivial merge overlap with #3 (both tidy the same import block). Independent of #4 (README).

🤖 Generated with [Claude Code](https://claude.com/claude-code)