### PR TITLE
feat: redact secrets from envelopes before they are stored or committed

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,9 +267,21 @@ our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Security
 
-Chronicle captures prompts, agent state, and retrieved context. Before recording
-production traffic, read the data-handling guidance in [SECURITY.md](SECURITY.md)
-and report vulnerabilities privately per that policy.
+Chronicle captures prompts, agent state, and retrieved context, so a recording can
+contain secrets. Turn on redaction before recording production traffic, so nothing
+sensitive reaches a committed fixture:
+
+```python
+import chronicle
+
+session = chronicle.reset_session()
+session.redactors = chronicle.default_redactors()   # mask API keys, tokens, JWTs
+```
+
+Redaction runs at record time and keeps the structure your tests assert on (message
+roles, tool names, argument keys) while masking the values. Add your own
+`(str) -> str` redactors for PII. Read the data-handling guidance in
+[SECURITY.md](SECURITY.md) and report vulnerabilities privately per that policy.
 
 ## Contact
 

--- a/chronicle/__init__.py
+++ b/chronicle/__init__.py
@@ -12,6 +12,7 @@ from chronicle.envelope.schema import (
     ToolSchema,
 )
 from chronicle.execution_graph import ExecutionGraph
+from chronicle.redaction import apply_redactors, default_redactors, redact_secrets
 from chronicle.replay.plan import BoundaryMode, ReplayPlan
 from chronicle.session import ChronicleSession, SessionMode, get_session, reset_session
 
@@ -19,15 +20,18 @@ __version__ = "0.1.0"
 
 __all__ = [
     "ActionResult",
+    "apply_redactors",
     "boundary",
     "BoundaryMode",
     "ChronicleSession",
     "ContextMetadata",
+    "default_redactors",
     "Envelope",
     "ExecutionGraph",
     "get_session",
     "InputState",
     "RagChunk",
+    "redact_secrets",
     "ReplayPlan",
     "reset_session",
     "SamplingParams",

--- a/chronicle/envelope/capture.py
+++ b/chronicle/envelope/capture.py
@@ -46,6 +46,7 @@ class EnvelopeRecorder:
         tool_schemas: list[ToolSchema] | None = None,
         framework: str = "langgraph",
         trace_id: str | None = None,
+        redactors: list[Callable[[str], str]] | None = None,
     ) -> None:
         if isinstance(store, str):
             store = EnvelopeStore(store)
@@ -56,6 +57,8 @@ class EnvelopeRecorder:
         self.tool_schemas = tool_schemas or []
         self.framework = framework
         self.trace_id = trace_id
+        # Applied before an envelope is stored, so secrets never reach a fixture.
+        self.redactors = redactors or []
 
     def _build_metadata(self, node_id: str) -> ContextMetadata:
         return ContextMetadata(
@@ -83,6 +86,10 @@ class EnvelopeRecorder:
             input_state=input_state,
             action_result=action_result,
         )
+        if self.redactors:
+            from chronicle.redaction import apply_redactors
+
+            envelope = apply_redactors(envelope, self.redactors)
         if self.store is not None:
             self.store.append(envelope)
         return envelope

--- a/chronicle/redaction.py
+++ b/chronicle/redaction.py
@@ -1,0 +1,91 @@
+"""Redact secrets from envelopes before they are retained, stored, or committed.
+
+A recorded run is a faithful copy of production input and output, so it can carry
+API keys, tokens, and other secrets straight into a fixture you commit to git.
+Redaction runs at record time and keeps the *structure* tests assert on (message
+roles, tool names, argument keys, finish reasons) while masking the *values*.
+
+By design this ships only high-confidence secret patterns that are almost never
+legitimate prompt or completion content. PII such as names and emails is context
+dependent, so it is left to opt-in redactors you add yourself rather than scrubbed
+by default.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from typing import Any
+
+from chronicle.envelope.schema import Envelope
+
+# A redactor maps a string to a redacted string. Compose several on a session.
+Redactor = Callable[[str], str]
+
+REDACTED = "[REDACTED]"
+
+# Shapes that are almost always secrets, safe to mask without mangling real text.
+DEFAULT_SECRET_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"sk-[A-Za-z0-9]{16,}"),                       # OpenAI-style keys
+    re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,}"),              # Slack tokens
+    re.compile(r"gh[pousr]_[A-Za-z0-9]{20,}"),               # GitHub tokens
+    re.compile(r"AKIA[0-9A-Z]{16}"),                          # AWS access key id
+    re.compile(r"(?i)bearer\s+[A-Za-z0-9._\-]{16,}"),         # bearer tokens
+    re.compile(r"eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]+"),  # JWTs
+    re.compile(
+        r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----[\s\S]+?"
+        r"-----END (?:RSA |EC |OPENSSH )?PRIVATE KEY-----"
+    ),
+]
+
+
+def redact_secrets(patterns: list[re.Pattern[str]] | None = None) -> Redactor:
+    """Return a redactor that masks high-confidence secret patterns.
+
+    Pass your own compiled patterns to extend or replace the defaults.
+    """
+    pats = DEFAULT_SECRET_PATTERNS if patterns is None else patterns
+
+    def _redact(text: str) -> str:
+        for pattern in pats:
+            text = pattern.sub(REDACTED, text)
+        return text
+
+    return _redact
+
+
+def default_redactors() -> list[Redactor]:
+    """The recommended baseline: mask common secret shapes."""
+    return [redact_secrets()]
+
+
+def _scrub(value: Any, redact: Redactor) -> Any:
+    if isinstance(value, str):
+        return redact(value)
+    if isinstance(value, list):
+        return [_scrub(item, redact) for item in value]
+    if isinstance(value, dict):
+        # Keys are structure (roles, argument names); only values are scrubbed.
+        return {key: _scrub(item, redact) for key, item in value.items()}
+    return value
+
+
+def apply_redactors(envelope: Envelope, redactors: list[Redactor]) -> Envelope:
+    """Return a copy of the envelope with every string in the input state and
+    action result passed through the redactors.
+
+    Identifiers, timestamps, and pinned metadata (model version, sampling params)
+    are left intact so the record stays diagnostically useful and replayable.
+    """
+    if not redactors:
+        return envelope
+
+    def run(text: str) -> str:
+        for redactor in redactors:
+            text = redactor(text)
+        return text
+
+    data = envelope.model_dump()
+    for section in ("input_state", "action_result"):
+        data[section] = _scrub(data[section], run)
+    return Envelope.model_validate(data)

--- a/chronicle/session.py
+++ b/chronicle/session.py
@@ -54,6 +54,10 @@ class ChronicleSession:
     # Optional observer for boundary crossings (LIVE record + LIVE cut-point).
     # Signature: (boundary_id, kind, input_state, result) -> None
     on_crossing: Callable[[str, str, InputState, Any], None] | None = None
+    # Applied to each envelope before it is retained or stored, so secrets never
+    # reach a committed fixture. Empty by default; set to default_redactors() or
+    # your own. Signature: (str) -> str. See chronicle.redaction.
+    redactors: list[Callable[[str], str]] = field(default_factory=list)
 
     _sequence: int = 0
     _invocation_counts: dict[str, int] = field(default_factory=dict)
@@ -157,6 +161,11 @@ class ChronicleSession:
             input_state=input_state,
             action_result=action_result,
         )
+
+        if self.redactors:
+            from chronicle.redaction import apply_redactors
+
+            envelope = apply_redactors(envelope, self.redactors)
 
         self._push_envelope(envelope.envelope_id)
         try:

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -1,0 +1,89 @@
+"""Redaction keeps envelope structure while masking secrets before storage."""
+
+from __future__ import annotations
+
+import pytest
+
+from chronicle import boundary, default_redactors, redact_secrets, reset_session
+from chronicle.envelope.store import EnvelopeStore
+
+SECRET_KEY = "sk-ABCD1234efgh5678IJKL"
+JWT = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.abcDEF123456"
+
+
+@pytest.mark.layer1
+def test_redact_secrets_masks_known_shapes_and_keeps_text():
+    r = redact_secrets()
+    assert SECRET_KEY not in r(f"my key is {SECRET_KEY} ok")
+    assert "[REDACTED]" in r(f"my key is {SECRET_KEY} ok")
+    assert r("delete the production database record 4471") == (
+        "delete the production database record 4471"
+    )  # ordinary text is untouched
+
+
+@pytest.mark.layer1
+def test_llm_boundary_redacts_prompt_and_completion():
+    @boundary("agent", kind="llm")
+    def agent(state: dict) -> dict:
+        return {"completion": f"sure, using {SECRET_KEY}", "finish_reason": "stop"}
+
+    session = reset_session()
+    session.redactors = default_redactors()
+    session.begin_trace("t-redact")
+    agent({"messages": [{"role": "user", "content": f"here is my token {SECRET_KEY}"}]})
+
+    env = session._recorded_envelopes[-1]
+    # Secret is gone from both input and output...
+    assert SECRET_KEY not in env.model_dump_json()
+    # ...but structure is intact: role preserved, finish_reason preserved.
+    assert env.input_state.messages[0]["role"] == "user"
+    assert env.action_result.finish_reason == "stop"
+
+
+@pytest.mark.layer1
+def test_tool_arguments_are_redacted():
+    @boundary("call_api", kind="tool")
+    def call_api(payload: dict) -> dict:
+        return {"status": "ok", "tool_calls": [
+            {"name": "call_api", "arguments": {"authorization": f"Bearer {JWT}"}}
+        ]}
+
+    session = reset_session()
+    session.redactors = default_redactors()
+    session.begin_trace("t-redact-tool")
+    call_api({"authorization": f"Bearer {JWT}"})
+
+    dumped = session._recorded_envelopes[-1].model_dump_json()
+    assert JWT not in dumped
+    assert "[REDACTED]" in dumped
+
+
+@pytest.mark.layer1
+def test_no_redactors_is_a_passthrough():
+    @boundary("agent", kind="llm")
+    def agent(state: dict) -> dict:
+        return {"completion": f"token {SECRET_KEY}"}
+
+    session = reset_session()  # no redactors set
+    session.begin_trace("t-none")
+    agent({"messages": []})
+
+    assert SECRET_KEY in session._recorded_envelopes[-1].model_dump_json()
+
+
+@pytest.mark.layer1
+def test_stored_file_is_redacted(tmp_path):
+    @boundary("agent", kind="llm")
+    def agent(state: dict) -> dict:
+        return {"completion": f"key {SECRET_KEY}", "finish_reason": "stop"}
+
+    store_path = tmp_path / "runs.jsonl"
+    session = reset_session()
+    session.redactors = default_redactors()
+    session.store = EnvelopeStore(store_path)
+    session.begin_trace("t-file")
+    agent({"messages": []})
+
+    on_disk = store_path.read_text(encoding="utf-8")
+    assert SECRET_KEY not in on_disk
+    assert "[REDACTED]" in on_disk


### PR DESCRIPTION
## Why
A recorded run is a faithful copy of production input/output, so a committed fixture can carry API keys, tokens, and PII straight into git. That is a hard adoption blocker: security and legal will veto committing raw traces. `SECURITY.md` warned about it; nothing enforced it. This makes the "commit the incident" workflow safe.

## What
- **`chronicle/redaction.py`**: `redact_secrets()` masks high-confidence secret shapes (OpenAI `sk-`, Slack, GitHub, AWS keys, bearer tokens, JWTs, PEM private keys); `default_redactors()`; `apply_redactors()` scrubs string values in `input_state` + `action_result` while **preserving structure** (message roles, tool names, argument keys, finish reasons) and identifiers/metadata.
- **Wired into both record paths**: `session.redactors` for the `@boundary` path and a `redactors=` arg on `EnvelopeRecorder` (LangGraph). Redaction happens before retention *and* storage, so persisted files, in-memory copies, and exported traces are all scrubbed.
- Exported `redact_secrets` / `default_redactors` / `apply_redactors` from the package root; documented in the README Security section.

```python
import chronicle
session = chronicle.reset_session()
session.redactors = chronicle.default_redactors()   # mask keys, tokens, JWTs
```

## Design notes
- **Opt-in (empty by default)** so it never surprises existing users by mangling content; the README recommends enabling it before recording prod.
- **Only high-confidence secrets by default.** PII (names, emails) is context-dependent, so it is left to custom `(str) -> str` redactors rather than scrubbed automatically.

## Tests
`tests/test_redaction.py` (5 cases): pattern masking vs ordinary text, prompt+completion redaction via `@boundary`, tool-argument redaction, passthrough when unset, and on-disk file redaction. **Full suite: 47 passed**, `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)