### PR TITLE
docs: post-release cleanup for v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,24 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-07-22
+
 ### Added
 - `@boundary` decorator: record in live mode, stub in replay mode, run live at a
-  cut-point — one annotation, three behaviors.
+  cut-point. One annotation, three behaviors.
 - Immutable, append-only Envelope capturing contextual metadata, input state,
   action/result, and graph linkage.
+- Real model-version and sampling-parameter capture on the `@boundary` path, plus
+  an `extract_metadata` hook for explicit overrides.
 - `EnvelopeStore` (JSONL) and a side execution graph builder.
 - Verification Test Bench: Layer 1 structural replay (never calls the LLM) and
   Layer 2 LLM-as-judge evaluation.
 - Cut-point replay via `ReplayPlan` (stub upstream, run target live, observe
   downstream).
+- Secret redaction: opt-in `session.redactors` / `default_redactors()` that mask
+  API keys, tokens, and JWTs before an envelope is stored or committed.
 - Trace visualizer (`chronicle show-graph --ui / --html`).
 - CLI: `record`, `extract`, `replay`, `verify`, `show-graph`, `schema`,
   `list-fixtures`.
 - OpenInference / Arize Phoenix normalization and optional LangGraph node
   wrapping.
 
-<!-- On release, rename this section to a version, e.g.:
-## [0.1.0] - 2026-07-22
-and start a fresh empty [Unreleased] section above it. -->
-
-[Unreleased]: https://github.com/theagentplane/chronicle/commits/main
+[Unreleased]: https://github.com/theagentplane/chronicle/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/theagentplane/chronicle/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Chronicle
 
 [![CI](https://github.com/theagentplane/chronicle/actions/workflows/ci.yml/badge.svg)](https://github.com/theagentplane/chronicle/actions/workflows/ci.yml)
+[![PyPI](https://img.shields.io/pypi/v/agent-chronicle.svg)](https://pypi.org/project/agent-chronicle/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE.txt)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://github.com/theagentplane/chronicle)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
@@ -61,7 +62,7 @@ tracing into this same envelope format.
 # From source (development):
 pip install -e ".[dev]"
 
-# From PyPI (coming soon; not yet published):
+# From PyPI:
 pip install agent-chronicle
 ```
 


### PR DESCRIPTION
Ready to merge **once `agent-chronicle` is live on PyPI**.

- **PyPI badge** re-added to the README (I'd removed it while it 404'd).
- **Install note** no longer says "coming soon".
- **CHANGELOG**: `[Unreleased]` promoted to **`[0.1.0] - 2026-07-22`**, with entries added for real model/sampling capture (#5) and secret redaction (#7), plus a fresh empty `[Unreleased]` and updated compare/tag links.

### Note on the redaction entry
The changelog lists **secret redaction** under 0.1.0, which assumes **#7 is merged before you cut the release**. If you decide to ship redaction in 0.1.1 instead, delete that one bullet before merging this.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)