### PR TITLE
fix: chronicle --version crash (release 0.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-07-22
+
+### Fixed
+- `chronicle --version` crashed on the installed CLI with `'chronicle' is not
+  installed`, because the version was resolved by import name rather than the
+  `agent-chronicle` distribution. It is now passed explicitly, so it works in
+  source, editable, and wheel installs.
+
 ## [0.1.0] - 2026-07-22
 
 ### Added
@@ -29,5 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OpenInference / Arize Phoenix normalization and optional LangGraph node
   wrapping.
 
-[Unreleased]: https://github.com/theagentplane/chronicle/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/theagentplane/chronicle/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/theagentplane/chronicle/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/theagentplane/chronicle/releases/tag/v0.1.0

--- a/chronicle/__init__.py
+++ b/chronicle/__init__.py
@@ -16,7 +16,7 @@ from chronicle.redaction import apply_redactors, default_redactors, redact_secre
 from chronicle.replay.plan import BoundaryMode, ReplayPlan
 from chronicle.session import ChronicleSession, SessionMode, get_session, reset_session
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 __all__ = [
     "ActionResult",

--- a/chronicle/cli.py
+++ b/chronicle/cli.py
@@ -7,6 +7,7 @@ import sys
 
 import click
 
+from chronicle import __version__
 from chronicle.envelope.schema import Envelope
 from chronicle.envelope.store import EnvelopeStore
 from chronicle.judge.runner import JudgeRunner, MockJudgeClient, OpenAIJudgeClient
@@ -14,7 +15,10 @@ from chronicle.replay.injector import ReplayInjector
 
 
 @click.group()
-@click.version_option()
+# Pass the version explicitly: the import package is `chronicle` but the
+# distribution is `agent-chronicle`, so click's default metadata lookup by
+# import name raises "'chronicle' is not installed".
+@click.version_option(version=__version__, prog_name="chronicle")
 def main() -> None:
     """Chronicle: Agent Data Recorder and Verification Test Bench."""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-chronicle"
-version = "0.1.0"
+version = "0.1.1"
 description = "Record-and-replay for agent decision graphs: reproduce a prod agent failure as a committed regression test — and re-run your fix without live LLM calls."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,29 @@
+"""CLI smoke tests.
+
+`chronicle --version` shipped broken in 0.1.0 because click looked up the
+distribution by the import name (`chronicle`) instead of `agent-chronicle`.
+These guard the entry point against that class of regression.
+"""
+
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+
+from chronicle import __version__
+from chronicle.cli import main
+
+
+@pytest.mark.layer1
+def test_version_flag_does_not_crash():
+    result = CliRunner().invoke(main, ["--version"])
+    assert result.exit_code == 0, result.output
+    assert __version__ in result.output
+
+
+@pytest.mark.layer1
+def test_help_lists_commands():
+    result = CliRunner().invoke(main, ["--help"])
+    assert result.exit_code == 0
+    for command in ("record", "replay", "verify", "show-graph", "schema"):
+        assert command in result.output


### PR DESCRIPTION
Found by a clean-venv smoke test of the **published 0.1.0 wheel**: `chronicle --version` crashes on every install.

```
RuntimeError: 'chronicle' is not installed. Try passing 'package_name' instead.
```

## Cause
The distribution is `agent-chronicle` but the import package is `chronicle`. `@click.version_option()` resolves the version via `importlib.metadata` **by import name**, so it looks up a distribution called `chronicle` (which does not exist) and raises.

## Fix
Pass the version explicitly: `@click.version_option(version=__version__, prog_name="chronicle")`. Works in source, editable, and wheel installs. `chronicle --version` now prints `chronicle, version 0.1.1`.

## Release
This ships as **0.1.1** (0.1.0 is already on PyPI and immutable):
- Bumped `pyproject.toml` and `chronicle.__version__` to `0.1.1`.
- Added `CHANGELOG.md` `[0.1.1]` entry.
- Added `tests/test_cli.py` guarding `--version` and `--help`.

Verified: `ruff` clean, **49 tests pass**, `python -m build` + `twine check` PASS for the 0.1.1 sdist/wheel.

## To publish after merge
Create a GitHub Release for **`v0.1.1`** (same flow as 0.1.0) to trigger `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)