### PR TITLE
feat: one-call record() / replay_trace() + README traction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `chronicle.record()` and `chronicle.replay_trace()` context managers that
+  collapse session setup (reset, attach store, begin or load trace, enable
+  replay) into a single `with` block. No behavior change; the same
+  `ChronicleSession` is yielded for finer control.
+
 ## [0.1.1] - 2026-07-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -68,12 +68,13 @@ pip install agent-chronicle
 
 ## Quick start
 
-The primary API is one decorator. Annotate a decision boundary once; it records
-in live mode and stubs from a fixture in replay mode.
+Annotate a decision boundary once with `@boundary`; it records in live mode and
+stubs from a fixture in replay mode. Record a run, and freeze it as a committed
+fixture, in a single block:
 
 ```python
-from chronicle import boundary, reset_session, ReplayPlan
-from chronicle.envelope.store import EnvelopeStore
+import chronicle
+from chronicle import boundary
 
 @boundary("agent", kind="llm")
 def agent_plan(state: dict) -> dict:
@@ -83,15 +84,16 @@ def agent_plan(state: dict) -> dict:
 def delete_file(path: str, environment: str) -> dict:
     ...
 
-# 1. Record a run (live mode is the default)
-session = reset_session()
-session.store = EnvelopeStore(".chronicle/runs/incident.jsonl")
-session.begin_trace("trace-001")
-run_agent(...)
-
-# 2. Freeze it as a committed fixture
-session.export_trace("fixtures/traces/incident-001/")
+with chronicle.record(
+    "incident-001",
+    store=".chronicle/runs/incident.jsonl",
+    export="fixtures/traces/incident-001/",
+):
+    run_agent(...)
 ```
+
+`record()` wraps `reset_session()`; drop to the session API when you need finer
+control.
 
 ### Cut-point replay
 
@@ -100,17 +102,18 @@ boundaries are stubbed from the fixture, your changed boundary runs live, and yo
 assert on its captured result.
 
 ```python
-session = reset_session()
-session.load_trace("fixtures/traces/deletion-incident-001/")
-session.enable_replay(
+import chronicle
+from chronicle import ReplayPlan
+
+with chronicle.replay_trace(
+    "fixtures/traces/deletion-incident-001/",
     ReplayPlan()
     .stub("agent", 1)          # upstream: frozen from fixture
     .live("delete_file", 1)    # cut-point: run new code
     .live("agent", 2)          # downstream: observe the effect
-)
-run_agent(...)
-
-assert session.captured_result("delete_file", 1)["blocked"] is True
+) as session:
+    run_agent(...)
+    assert session.captured_result("delete_file", 1)["blocked"] is True
 ```
 
 One decorator, two behaviors: in **live** mode your function runs and its
@@ -260,6 +263,13 @@ scripts/                   # demo and test runners
 tests/                     # unit + e2e
 ```
 
+## Talks and writing
+
+This work was presented at the **AI Engineer World's Fair 2026**.
+
+- [Your Agent Failed in Prod. Good Luck Reproducing It](https://dev.to/tisha/your-agent-failed-in-prod-good-luck-reproducing-it-56ci): why record and replay beats forcing determinism.
+- [You Recorded the Incident. Now Prove Your Fix Actually Works](https://dev.to/tisha/you-recorded-the-incident-now-prove-your-fix-actually-works-2cni): cut-point replay, turning an incident into a regression test.
+
 ## Contributing
 
 Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for dev setup,
@@ -292,3 +302,7 @@ roles, tool names, argument keys) while masking the values. Add your own
 ## License
 
 [MIT](LICENSE.txt) (c) 2026 Susheem Koul and Tisha Chawla.
+
+---
+
+If Chronicle saves you a debugging session, please [star the repo](https://github.com/theagentplane/chronicle) so more people can find it.

--- a/chronicle/__init__.py
+++ b/chronicle/__init__.py
@@ -1,5 +1,6 @@
 """Chronicle: Agent Data Recorder and Verification Test Bench."""
 
+from chronicle.api import record, replay_trace
 from chronicle.boundary import boundary
 from chronicle.envelope.schema import (
     ActionResult,
@@ -31,7 +32,9 @@ __all__ = [
     "get_session",
     "InputState",
     "RagChunk",
+    "record",
     "redact_secrets",
+    "replay_trace",
     "ReplayPlan",
     "reset_session",
     "SamplingParams",

--- a/chronicle/api.py
+++ b/chronicle/api.py
@@ -1,0 +1,81 @@
+"""One-call context managers over the session for the common flows.
+
+These add no new behavior. They collapse the setup boilerplate (reset the
+session, attach a store, begin or load a trace, enable replay) into a single
+``with`` block, and hand you the same ``ChronicleSession`` so anything the
+lower-level API can do is still available.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+from chronicle.envelope.store import EnvelopeStore
+from chronicle.replay.plan import ReplayPlan
+from chronicle.session import ChronicleSession, reset_session
+
+
+@contextmanager
+def record(
+    trace_id: str | None = None,
+    *,
+    store: EnvelopeStore | str | Path | None = None,
+    model_version: str | None = None,
+    build_id: str | None = None,
+    redactors: list[Callable[[str], str]] | None = None,
+    export: str | Path | None = None,
+) -> Iterator[ChronicleSession]:
+    """Record a run in one block.
+
+    Replaces the reset_session / attach store / begin_trace boilerplate. On a
+    clean exit, if ``export`` is given, the trace graph is written there so the
+    incident is ready to commit as a fixture.
+
+        with chronicle.record(
+            "incident-001",
+            store=".chronicle/runs/incident.jsonl",
+            export="fixtures/traces/incident-001/",
+        ) as session:
+            run_agent(...)
+    """
+    session = reset_session()
+    if store is not None:
+        session.store = store if isinstance(store, EnvelopeStore) else EnvelopeStore(store)
+    if model_version is not None:
+        session.model_version = model_version
+    if build_id is not None:
+        session.build_id = build_id
+    if redactors is not None:
+        session.redactors = redactors
+    session.begin_trace(trace_id)
+    yield session
+    # Export only on a clean exit, so a crash mid-run doesn't overwrite a fixture
+    # with a partial trace. Call session.export_trace(...) yourself if you need it.
+    if export is not None:
+        session.export_trace(export)
+
+
+@contextmanager
+def replay_trace(
+    trace: str | Path,
+    plan: ReplayPlan | None = None,
+) -> Iterator[ChronicleSession]:
+    """Replay a recorded trace in one block.
+
+    Replaces reset_session / load_trace / enable_replay. Pass a ``ReplayPlan`` to
+    stub upstream boundaries and run one live at a cut-point; omit it to stub
+    everything.
+
+        with chronicle.replay_trace(
+            "fixtures/traces/incident-001/",
+            ReplayPlan().stub("agent", 1).live("delete_file", 1).live("agent", 2),
+        ) as session:
+            run_agent(...)
+            assert session.captured_result("delete_file", 1)["blocked"] is True
+    """
+    session = reset_session()
+    session.load_trace(trace)
+    session.enable_replay(plan)
+    yield session

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,64 @@
+"""One-call record() / replay_trace() context managers.
+
+These wrap the existing session API, so the tests focus on the ergonomics:
+setup happens for you, and a record then replay round trip behaves the same as
+the longhand form.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import chronicle
+from chronicle import ReplayPlan, boundary
+
+SECRET = "sk-ABCD1234efgh5678IJKL"
+
+
+@pytest.mark.layer1
+def test_record_then_replay_trace_roundtrip(tmp_path):
+    @boundary("tool", kind="tool")
+    def tool(x: str) -> dict:
+        return {"status": "done", "value": x}
+
+    trace_dir = tmp_path / "trace"
+    with chronicle.record(
+        "t1", store=str(tmp_path / "runs.jsonl"), export=str(trace_dir)
+    ) as session:
+        tool("real")
+
+    # Recording happened, the store was written, and the trace was exported.
+    assert len(session._recorded_envelopes) == 1
+    assert (tmp_path / "runs.jsonl").read_text(encoding="utf-8").strip()
+    assert trace_dir.exists()
+
+    # Replaying the exported trace stubs the tool with its recorded result.
+    with chronicle.replay_trace(str(trace_dir), ReplayPlan().stub("tool", 1)):
+        result = tool("ignored-in-replay")
+
+    assert result["status"] == "done"
+    assert result["value"] == "real"
+
+
+@pytest.mark.layer1
+def test_record_applies_redactors(tmp_path):
+    @boundary("agent", kind="llm")
+    def agent(state: dict) -> dict:
+        return {"completion": f"key {SECRET}", "finish_reason": "stop"}
+
+    with chronicle.record("t", redactors=chronicle.default_redactors()) as session:
+        agent({"messages": []})
+
+    assert SECRET not in session._recorded_envelopes[-1].model_dump_json()
+
+
+@pytest.mark.layer1
+def test_record_without_export_leaves_no_fixture(tmp_path):
+    @boundary("agent", kind="llm")
+    def agent(state: dict) -> dict:
+        return {"completion": "ok"}
+
+    with chronicle.record("t") as session:
+        agent({"messages": []})
+
+    assert len(session._recorded_envelopes) == 1  # recorded in memory, nothing exported


### PR DESCRIPTION
Makes the common flows dramatically simpler to adopt **without changing any behavior**, and adds adoption surface to the README.

## Simpler API (same functionality)
Two context managers that wrap the existing session calls:

**Record (before → after):**
```python
# before
session = reset_session()
session.store = EnvelopeStore(".chronicle/runs/incident.jsonl")
session.begin_trace("incident-001")
run_agent(...)
session.export_trace("fixtures/traces/incident-001/")

# after
with chronicle.record("incident-001",
                      store=".chronicle/runs/incident.jsonl",
                      export="fixtures/traces/incident-001/"):
    run_agent(...)
```

**Cut-point replay:**
```python
with chronicle.replay_trace("fixtures/traces/incident-001/",
        ReplayPlan().stub("agent", 1).live("delete_file", 1).live("agent", 2)) as session:
    run_agent(...)
    assert session.captured_result("delete_file", 1)["blocked"] is True
```

Both yield the same `ChronicleSession`, so nothing is hidden or lost. `record()` exports on clean exit only (a crash won't overwrite a fixture with a partial trace). Named `replay_trace` (not `replay`) to avoid shadowing the `chronicle.replay` subpackage.

## README (traction)
- Quick start and cut-point sections now show the one-call API.
- New **Talks and writing** section: presented at the **AI Engineer World's Fair 2026**, with links to both dev.to posts (Part 1 and Part 2).
- **Star CTA** at the bottom.

## Tests
`tests/test_api.py`: record → replay_trace round trip, redaction via `record()`, and the no-export case. **52 passed**, `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)