### PR TITLE
chore: release 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-07-23
+
 ### Added
 - `chronicle.record()` and `chronicle.replay_trace()` context managers that
   collapse session setup (reset, attach store, begin or load trace, enable
@@ -43,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OpenInference / Arize Phoenix normalization and optional LangGraph node
   wrapping.
 
-[Unreleased]: https://github.com/theagentplane/chronicle/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/theagentplane/chronicle/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/theagentplane/chronicle/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/theagentplane/chronicle/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/theagentplane/chronicle/releases/tag/v0.1.0

--- a/chronicle/__init__.py
+++ b/chronicle/__init__.py
@@ -17,7 +17,7 @@ from chronicle.redaction import apply_redactors, default_redactors, redact_secre
 from chronicle.replay.plan import BoundaryMode, ReplayPlan
 from chronicle.session import ChronicleSession, SessionMode, get_session, reset_session
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 __all__ = [
     "ActionResult",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-chronicle"
-version = "0.1.1"
+version = "0.1.2"
 description = "Record-and-replay for agent decision graphs: reproduce a prod agent failure as a committed regression test — and re-run your fix without live LLM calls."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Prep for the **v0.1.2** release. Merge this, then create the GitHub Release for `v0.1.2` to publish.

- Bump `version` to `0.1.2` in `pyproject.toml` and `chronicle.__version__`.
- Promote the CHANGELOG `[Unreleased]` block to **`[0.1.2] - 2026-07-23`** (the one-call `record()` / `replay_trace()` context managers) and start a fresh `[Unreleased]`.

Verified: `chronicle --version` prints `0.1.2`, **52 tests pass**, `python -m build` + `twine check` PASS for the 0.1.2 sdist/wheel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)