### PR TITLE
ci: guard release tag against pyproject version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,18 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Verify tag matches package version
+        # Guard against cutting a release before the version bump is merged:
+        # the tag (vX.Y.Z) must match pyproject's version, or we would publish
+        # the wrong version under the tag's name.
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          version="$(grep -m1 '^version' pyproject.toml | sed -E 's/.*"([^"]+)".*/\1/')"
+          echo "release tag: $tag | pyproject version: $version"
+          if [ "$tag" != "$version" ]; then
+            echo "::error::Release tag v$tag does not match pyproject version $version. Bump the version and merge it before creating the release."
+            exit 1
+          fi
       - name: Build sdist and wheel
         run: |
           pip install "build>=1.2"


### PR DESCRIPTION
**Why:** the v0.1.2 GitHub Release was created before #14 (the version bump) merged, so `release.yml` built and published **0.1.1** under the `v0.1.2` tag. That is why PyPI shows 0.1.1.

**Fix:** the build job now fails fast if the release tag (`vX.Y.Z`) does not equal `pyproject.toml`'s version, so a mismatched release can never publish the wrong artifact again.

Merge this before re-cutting the 0.1.2 release.