### PR TITLE
Release v0.1.3: wrap_llm for LLM tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-07-23
+
+### Added
+- `chronicle.wrap_llm(boundary_id, dispatch, ...)` — wrap an LLM callable with the
+  same LIVE / stub / cut-point + `on_crossing` contract as `@boundary(..., kind="llm")`,
+  so governors (e.g. TokenOps) can subscribe without a parallel tracer.
+
 ## [0.1.2] - 2026-07-23
 
 ### Added
@@ -45,7 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OpenInference / Arize Phoenix normalization and optional LangGraph node
   wrapping.
 
-[Unreleased]: https://github.com/theagentplane/chronicle/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/theagentplane/chronicle/compare/v0.1.3...HEAD
+[0.1.3]: https://github.com/theagentplane/chronicle/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/theagentplane/chronicle/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/theagentplane/chronicle/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/theagentplane/chronicle/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -265,8 +265,8 @@ See `examples/langgraph_demo/agent.py`.
 
 ## Cost and governance observers (`on_crossing`)
 
-Chronicle does not embed cost management. External systems (for example TokenOps)
-attach an observer that fires after each live crossing:
+Chronicle is the tracer; governors subscribe via `on_crossing`. External systems
+(for example TokenOps) attach an observer that fires after each live crossing:
 
 ```python
 session = reset_session()
@@ -276,6 +276,26 @@ session.on_crossing = my_observer  # (boundary_id, kind, input_state, result) ->
 It runs after a live envelope record and a live cut-point capture, and does not
 run on stub replay. See `tests/test_cost_management_e2e.py` for an end-to-end
 ledger and budget pattern.
+
+### Wrapping LLM dispatch (`wrap_llm`)
+
+When the LLM entry point is a callable (not a decorate-able function), use
+`wrap_llm` — same record + `on_crossing` contract as `@boundary(..., kind="llm")`:
+
+```python
+from chronicle import wrap_llm
+
+def complete(provider, model, messages, **kwargs):
+    ...
+
+traced = wrap_llm("agent.chat", complete)
+# LIVE: executes, records envelope kind=llm, fires on_crossing
+# REPLAY stub: returns fixture without calling complete
+result = traced("openai", "gpt-4o-mini", [{"role": "user", "content": "hi"}])
+```
+
+Also accepts `(messages) -> result`. Pass `extract_input` / `extract_result` /
+`extract_metadata` when the signature differs.
 
 ## Environment variables
 
@@ -292,7 +312,7 @@ under `examples/`; committed regression traces live in `fixtures/`.
 
 ```
 chronicle/                 # installable package
-├── boundary.py            # @boundary decorator (record + replay + cut-point)
+├── boundary.py            # @boundary + wrap_llm (record + replay + cut-point)
 ├── session.py             # runtime session, on_crossing hook, stub/live modes
 ├── execution_graph.py     # side graph builder (load/save/render)
 ├── visualizer.py          # HTML trace UI (library + CLI)

--- a/chronicle/__init__.py
+++ b/chronicle/__init__.py
@@ -1,7 +1,7 @@
 """Chronicle: Agent Data Recorder and Verification Test Bench."""
 
 from chronicle.api import record, replay_trace
-from chronicle.boundary import boundary
+from chronicle.boundary import boundary, wrap_llm
 from chronicle.envelope.schema import (
     ActionResult,
     ContextMetadata,
@@ -17,12 +17,13 @@ from chronicle.redaction import apply_redactors, default_redactors, redact_secre
 from chronicle.replay.plan import BoundaryMode, ReplayPlan
 from chronicle.session import ChronicleSession, SessionMode, get_session, reset_session
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 __all__ = [
     "ActionResult",
     "apply_redactors",
     "boundary",
+    "wrap_llm",
     "BoundaryMode",
     "ChronicleSession",
     "ContextMetadata",

--- a/chronicle/boundary.py
+++ b/chronicle/boundary.py
@@ -41,28 +41,86 @@ def boundary(
     """
 
     def decorator(fn: F) -> F:
-        @functools.wraps(fn)
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
-            session = get_session()
-
-            if session.mode == SessionMode.LIVE:
-                return _record_call(
-                    session, fn, boundary_id, kind, args, kwargs,
-                    extract_input, extract_result, extract_metadata,
-                )
-
-            invocation_index = session._replay_cursor.get(boundary_id, 0) + 1
-            if session.replay_plan.should_stub(boundary_id, invocation_index):
-                return session.stub_result(boundary_id, kind)
-
-            return _live_cutpoint_call(
-                session, fn, boundary_id, kind, args, kwargs,
-                extract_input, extract_result, invocation_index,
-            )
-
-        return wrapper  # type: ignore[return-value]
+        return _bind_boundary(  # type: ignore[return-value]
+            fn,
+            boundary_id,
+            kind,
+            extract_input=extract_input,
+            extract_result=extract_result,
+            extract_metadata=extract_metadata,
+        )
 
     return decorator
+
+
+def wrap_llm(
+    boundary_id: str,
+    dispatch: Callable[..., Any],
+    *,
+    extract_input: Callable[..., InputState] | None = None,
+    extract_result: Callable[[Any], Any] | None = None,
+    extract_metadata: Callable[[Any], Mapping[str, Any]] | None = None,
+) -> Callable[..., Any]:
+    """Wrap an LLM callable with Chronicle tracing (``kind="llm"``).
+
+    Chronicle owns the tracer; governors subscribe via ``session.on_crossing``.
+    Same LIVE / stub-replay / live cut-point contract as
+    ``@boundary(..., kind="llm")``: execute + record envelope, then fire
+    ``on_crossing(boundary_id, kind, input_state, result)``.
+
+    Prefer this when the LLM entry point is a dispatch function rather than a
+    named method you can decorate (e.g. TokenOps ``wrap_complete`` bridging).
+
+    Common dispatch shapes (default ``extract_input`` handles these):
+
+    - ``(messages) -> result`` / ``(messages, **kwargs) -> result``
+    - ``(provider, model, messages, **kwargs) -> result``
+    - graph-state ``({"messages": ...},) -> result`` (same as ``@boundary``)
+
+    Pass ``extract_input`` / ``extract_result`` / ``extract_metadata`` when the
+    callable does not match those shapes.
+    """
+    return _bind_boundary(
+        dispatch,
+        boundary_id,
+        "llm",
+        extract_input=extract_input if extract_input is not None else _llm_default_input,
+        extract_result=extract_result,
+        extract_metadata=extract_metadata,
+    )
+
+
+def _bind_boundary(
+    fn: Callable[..., Any],
+    boundary_id: str,
+    kind: str,
+    *,
+    extract_input: Callable[..., InputState] | None,
+    extract_result: Callable[[Any], Any] | None,
+    extract_metadata: Callable[[Any], Mapping[str, Any]] | None,
+) -> Callable[..., Any]:
+    """Shared LIVE / replay wrapper used by ``@boundary`` and ``wrap_llm``."""
+
+    @functools.wraps(fn)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        session = get_session()
+
+        if session.mode == SessionMode.LIVE:
+            return _record_call(
+                session, fn, boundary_id, kind, args, kwargs,
+                extract_input, extract_result, extract_metadata,
+            )
+
+        invocation_index = session._replay_cursor.get(boundary_id, 0) + 1
+        if session.replay_plan.should_stub(boundary_id, invocation_index):
+            return session.stub_result(boundary_id, kind)
+
+        return _live_cutpoint_call(
+            session, fn, boundary_id, kind, args, kwargs,
+            extract_input, extract_result, invocation_index,
+        )
+
+    return wrapper
 
 
 def _default_input_state(args: tuple, kwargs: dict) -> InputState:
@@ -83,6 +141,49 @@ def _default_input_state(args: tuple, kwargs: dict) -> InputState:
         system_prompt=graph_state.get("system_prompt"),
         graph_state=graph_state,
     )
+
+
+def _llm_default_input(*args: Any, **kwargs: Any) -> InputState:
+    """Best-effort ``InputState`` for common LLM dispatch signatures."""
+    if "messages" in kwargs:
+        messages = list(kwargs["messages"])
+        graph_state = dict(kwargs)
+        graph_state["messages"] = messages
+        return InputState(
+            messages=messages,
+            system_prompt=graph_state.get("system_prompt"),
+            graph_state=graph_state,
+        )
+
+    if args and isinstance(args[0], dict):
+        return _default_input_state(args, kwargs)
+
+    if len(args) >= 3 and isinstance(args[2], (list, tuple)):
+        # (provider, model, messages, **kwargs)
+        messages = list(args[2])
+        graph_state: dict[str, Any] = {
+            "provider": args[0],
+            "model": args[1],
+            "messages": messages,
+            **kwargs,
+        }
+        return InputState(
+            messages=messages,
+            system_prompt=graph_state.get("system_prompt"),
+            graph_state=graph_state,
+        )
+
+    if args and isinstance(args[0], (list, tuple)):
+        # (messages) or (messages, **kwargs)
+        messages = list(args[0])
+        graph_state = {"messages": messages, **kwargs}
+        return InputState(
+            messages=messages,
+            system_prompt=graph_state.get("system_prompt"),
+            graph_state=graph_state,
+        )
+
+    return _default_input_state(args, kwargs)
 
 
 def _record_call(session, fn, boundary_id, kind, args, kwargs, extract_input, extract_result, extract_metadata):

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,8 +8,8 @@ Demos and test benches live here — **not** in the installable `chronicle` pack
 | `financial_incidents/` | Refund / invoice / trade incident demos (+ screenshot assets) |
 | `langgraph_demo/` | Optional LangGraph node-wrapping example |
 
-**Core library** (importable): `chronicle/` — `@boundary`, session, envelopes, replay, judge, CLI, visualizer API.
+**Core library** (importable): `chronicle/` — `@boundary`, `wrap_llm`, session, envelopes, replay, judge, CLI, visualizer API.
 
 **Regression fixtures** (committed traces/envelopes): `fixtures/` — used by demos and pytest; not shipped as package code.
 
-**Integration point for external cost observers** (e.g. TokenOps): set `session.on_crossing` — see `tests/test_cost_management_e2e.py`. Chronicle does not import cost-management products.
+**Integration point for external cost observers** (e.g. TokenOps): Chronicle is the tracer (`@boundary` / `wrap_llm`); governors subscribe via `session.on_crossing` — see `tests/test_cost_management_e2e.py`. Chronicle does not import cost-management products.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-chronicle"
-version = "0.1.2"
+version = "0.1.3"
 description = "Record-and-replay for agent decision graphs: reproduce a prod agent failure as a committed regression test — and re-run your fix without live LLM calls."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_wrap_llm.py
+++ b/tests/test_wrap_llm.py
@@ -1,0 +1,178 @@
+"""Unit tests for wrap_llm — Chronicle-owned LLM tracing."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from chronicle.boundary import wrap_llm
+from chronicle.envelope.schema import InputState
+from chronicle.replay.plan import ReplayPlan
+from chronicle.session import reset_session
+
+
+def _complete(provider: str, model: str, messages: list, **kwargs) -> dict:
+    return {
+        "completion": f"{provider}/{model}:{len(messages)}",
+        "finish_reason": "stop",
+        "model": model,
+        "temperature": kwargs.get("temperature", 0.0),
+        "usage": {"input_tokens": 3, "output_tokens": 2},
+    }
+
+
+@pytest.mark.layer1
+def test_wrap_llm_records_envelope_kind_llm():
+    session = reset_session()
+    session.enable_live()
+    session.begin_trace("wrap-llm-record")
+
+    traced = wrap_llm("agent.chat", _complete)
+    out = traced(
+        "openai",
+        "gpt-4o-mini",
+        [{"role": "user", "content": "hi"}],
+        temperature=0.2,
+    )
+
+    assert out["completion"] == "openai/gpt-4o-mini:1"
+    assert len(session._recorded_envelopes) == 1
+    env = session._recorded_envelopes[0]
+    assert env.boundary_kind == "llm"
+    assert env.node_id == "agent.chat"
+    assert env.metadata.model_version == "gpt-4o-mini"
+    assert env.metadata.sampling_params.temperature == 0.2
+    assert env.input_state.messages == [{"role": "user", "content": "hi"}]
+    assert env.input_state.graph_state["provider"] == "openai"
+    assert env.input_state.graph_state["model"] == "gpt-4o-mini"
+
+
+@pytest.mark.layer1
+def test_wrap_llm_invokes_on_crossing_with_kind_llm():
+    session = reset_session()
+    session.enable_live()
+    crossings: list[tuple] = []
+
+    def hook(boundary_id, kind, input_state, result):
+        crossings.append((boundary_id, kind, input_state, result))
+
+    session.on_crossing = hook
+    traced = wrap_llm("planner.chat", _complete)
+
+    out = traced("openai", "gpt-4o-mini", [{"role": "user", "content": "plan"}])
+    assert out["finish_reason"] == "stop"
+    assert len(crossings) == 1
+    bid, kind, inp, result = crossings[0]
+    assert bid == "planner.chat"
+    assert kind == "llm"
+    assert isinstance(inp, InputState)
+    assert inp.messages[0]["content"] == "plan"
+    assert result == out
+
+
+@pytest.mark.layer1
+def test_wrap_llm_messages_only_signature():
+    session = reset_session()
+    session.enable_live()
+    crossings: list[tuple] = []
+    session.on_crossing = lambda *a: crossings.append(a)
+
+    def complete(messages, **kwargs):
+        return {"completion": messages[-1]["content"], "finish_reason": "stop"}
+
+    traced = wrap_llm("simple.chat", complete)
+    out = traced([{"role": "user", "content": "hello"}])
+
+    assert out["completion"] == "hello"
+    assert len(session._recorded_envelopes) == 1
+    assert session._recorded_envelopes[0].boundary_kind == "llm"
+    assert crossings[0][1] == "llm"
+    assert crossings[0][2].messages[0]["content"] == "hello"
+
+
+@pytest.mark.layer1
+def test_wrap_llm_stub_replay_skips_dispatch_and_on_crossing(tmp_path):
+    session = reset_session()
+    session.enable_live()
+    traced = wrap_llm("agent.chat", _complete)
+    traced("openai", "gpt-4o-mini", [{"role": "user", "content": "fixture"}])
+    trace_dir = tmp_path / "trace"
+    session.export_trace(trace_dir)
+
+    calls: list[tuple] = []
+
+    def counting_dispatch(provider, model, messages, **kwargs):
+        calls.append((provider, model, messages))
+        return _complete(provider, model, messages, **kwargs)
+
+    session = reset_session()
+    session.load_trace(trace_dir)
+    session.enable_replay(ReplayPlan().stub("agent.chat", 1))
+    crossings: list[tuple] = []
+    session.on_crossing = lambda *args: crossings.append(args)
+
+    traced = wrap_llm("agent.chat", counting_dispatch)
+    out = traced("openai", "gpt-4o-mini", [{"role": "user", "content": "ignored"}])
+
+    assert out["completion"] == "openai/gpt-4o-mini:1"  # from fixture
+    assert calls == []
+    assert crossings == []
+
+
+@pytest.mark.layer1
+def test_wrap_llm_live_cutpoint_fires_on_crossing(tmp_path):
+    session = reset_session()
+    session.enable_live()
+    traced = wrap_llm("agent.chat", _complete)
+    traced("openai", "gpt-4o-mini", [{"role": "user", "content": "fixture"}])
+    trace_dir = tmp_path / "trace"
+    session.export_trace(trace_dir)
+
+    session = reset_session()
+    session.load_trace(trace_dir)
+    session.enable_replay(ReplayPlan().live("agent.chat", 1))
+    crossings: list[tuple] = []
+    session.on_crossing = lambda *args: crossings.append(args)
+
+    traced = wrap_llm("agent.chat", _complete)
+    out = traced(
+        "openai",
+        "gpt-4o-mini",
+        [{"role": "user", "content": "cutpoint"}],
+    )
+
+    assert out["completion"] == "openai/gpt-4o-mini:1"
+    assert len(crossings) == 1
+    bid, kind, inp, result = crossings[0]
+    assert bid == "agent.chat"
+    assert kind == "llm"
+    assert inp.messages[0]["content"] == "cutpoint"
+    assert session.captured_result("agent.chat", 1) == result
+
+
+@pytest.mark.layer1
+def test_wrap_llm_custom_extract_input():
+    session = reset_session()
+    session.enable_live()
+
+    def extract_input(prompt: str) -> InputState:
+        return InputState(
+            messages=[{"role": "user", "content": prompt}],
+            graph_state={"prompt": prompt},
+        )
+
+    def complete(prompt: str) -> dict:
+        return {"completion": prompt.upper(), "finish_reason": "stop"}
+
+    traced = wrap_llm("custom.chat", complete, extract_input=extract_input)
+    out = traced("hi")
+
+    assert out["completion"] == "HI"
+    env = session._recorded_envelopes[0]
+    assert env.boundary_kind == "llm"
+    assert env.input_state.graph_state["prompt"] == "hi"


### PR DESCRIPTION
## Summary
- Add `chronicle.wrap_llm` with the same record + `on_crossing` contract as `@boundary(..., kind=\"llm\")`.
- Bump to **0.1.3** for TokenOps (and others) to pin `agent-chronicle>=0.1.3`.

## Test plan
- [x] `pytest tests/test_wrap_llm.py tests/test_on_crossing.py`
- [ ] After merge: tag `v0.1.3` and publish GitHub Release to trigger PyPI Trusted Publishing

Made with [Cursor](https://cursor.com)