### PR TITLE
feat: chronicle.wrap(client) + instrument_langgraph (2-line adoption)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for some call patterns, so fixtures recorded before 0.2 may need re-recording.
 
 ### Added
+- **`chronicle.wrap(client)`**: record every model call an OpenAI/Anthropic-style
+  client makes, with no decorators; in replay it returns the recorded response
+  (attribute/index access) and makes no API call.
+- **`chronicle.instrument_langgraph(nodes)`**: wrap every LangGraph node as a
+  `@boundary` in one call (record / stub-replay / cut-point; async supported).
 - **Async support**: `async def` boundaries record, stub on replay, and run live at
   a cut-point exactly like sync ones (via `@boundary` and `wrap_llm`); LangGraph
   `EnvelopeRecorder.wrap_node` gains the same async path.

--- a/README.md
+++ b/README.md
@@ -86,9 +86,21 @@ pip install agent-chronicle
 
 ## Quick start
 
-Annotate a decision boundary once with `@boundary`; it records in live mode and
-stubs from a fixture in replay mode. Record a run, and freeze it as a committed
-fixture, in a single block:
+The fastest start is to **wrap your LLM client**: no decorators, and every model
+call is recorded and replayable:
+
+```python
+import chronicle
+from openai import OpenAI
+
+client = chronicle.wrap(OpenAI())
+client.chat.completions.create(model="gpt-4o", messages=[...])   # recorded
+```
+
+For control over what counts as a boundary, annotate the functions that call the
+model or a tool with `@boundary`; it records in live mode and stubs from a fixture
+in replay mode. Record a run, and freeze it as a committed fixture, in a single
+block:
 
 ```python
 import chronicle
@@ -247,8 +259,19 @@ chronicle list-fixtures                             # list committed envelope fi
 
 ## LangGraph integration (optional)
 
+Wrap every node in one call, so each records and replays via `@boundary` (async
+nodes supported):
+
+```python
+import chronicle
+
+nodes = chronicle.instrument_langgraph({"agent": agent_node, "tools": tool_node})
+for name, fn in nodes.items():
+    graph.add_node(name, fn)
+```
+
 <details>
-<summary><b>Wrap LangGraph nodes as an alternative to <code>@boundary</code></b></summary>
+<summary><b>Lower-level: EnvelopeRecorder</b></summary>
 
 ```python
 from chronicle.envelope.capture import EnvelopeRecorder
@@ -342,10 +365,9 @@ This work was presented at the **AI Engineer World's Fair 2026**.
 
 Chronicle is early (0.x), and the Envelope schema may still change. Near-term:
 
-- Drop-in provider capture: `chronicle.wrap(client)` for OpenAI and Anthropic.
-- One-call LangGraph instrumentation (auto-record every node) and a docs site.
 - A pytest plugin so a committed incident becomes a one-decorator regression test.
-- Async generators / streaming (SSE) capture.
+- Auto-instrument a compiled LangGraph app and capture routing / edge decisions.
+- Async generators / streaming (SSE) capture, and a docs site.
 
 Ideas and priorities are welcome in [Discussions](https://github.com/theagentplane/chronicle/discussions).
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ regression test and re-run your fix without live LLM calls. The target is one sp
 real problem: control-flow and tool-safety regressions in multi-agent systems, caught
 deterministically from recorded incidents.
 
-**[Why](#why-chronicle) · [Architecture](#architecture) · [Install](#install) · [Quick start](#quick-start) · [Verification](#verification-layers) · [Demos](#demos) · [Comparison](#how-chronicle-compares) · [CLI](#cli) · [Roadmap](#roadmap)**
+**[Why](#why-chronicle) · [Architecture](#architecture) · [Install](#install) · [Quick start](#quick-start) · [Verification](#verification-layers) · [Demos](#demos) · [Comparison](#how-chronicle-compares) · [CLI](#cli) · [Roadmap](#roadmap) · [FAQ](#faq)**
 
 ## Why Chronicle
 
@@ -343,11 +343,51 @@ This work was presented at the **AI Engineer World's Fair 2026**.
 Chronicle is early (0.x), and the Envelope schema may still change. Near-term:
 
 - Drop-in provider capture: `chronicle.wrap(client)` for OpenAI and Anthropic.
-- Async `@boundary` for async agents and graph nodes.
+- One-call LangGraph instrumentation (auto-record every node) and a docs site.
 - A pytest plugin so a committed incident becomes a one-decorator regression test.
-- One-call LangGraph instrumentation and a documentation site.
+- Async generators / streaming (SSE) capture.
 
 Ideas and priorities are welcome in [Discussions](https://github.com/theagentplane/chronicle/discussions).
+
+## FAQ
+
+**Does replaying call my LLM?**
+No. Layer 1 replay never calls the model; it returns the outputs recorded during the
+live run, so tests are deterministic, free, and fast. Only the optional Layer 2
+(LLM-as-judge) makes calls, and only when you ask it to.
+
+**How is this different from LangSmith, Langfuse, or Phoenix?**
+Those are tracing and eval dashboards for observing runs. Chronicle turns a recorded
+run into a deterministic, replayable regression test, and lets you re-run one boundary
+against a real incident (cut-point replay). They are complementary: trace with one,
+reproduce and test with Chronicle.
+
+**Does it work with async / FastAPI?**
+Yes. `async def` boundaries record, stub, and cut-point exactly like sync ones, and the
+session is per-request isolated, so concurrent requests never share a trace.
+
+**Does it work with LangGraph?**
+Yes. Decorate nodes with `@boundary`, or wrap them with `EnvelopeRecorder`. One-call
+graph instrumentation is on the roadmap.
+
+**What about non-determinism?**
+You do not force the model to be deterministic. You record the run and replay it, which
+is the only thing you actually need. (More in the
+[write-up](https://dev.to/tisha/your-agent-failed-in-prod-good-luck-reproducing-it-56ci).)
+
+**Will recording change production behavior?**
+No. `@boundary` is transparent: it never changes what your function returns or raises.
+Enable it where you want to record.
+
+**What about secrets and PII?**
+Turn on redaction before recording production traffic
+(`session.redactors = chronicle.default_redactors()`); secrets are masked before
+anything is stored or committed.
+
+**What does Chronicle not do?**
+It reproduces control-flow and tool-safety bugs deterministically. It does not fix a bad
+generation: if the model hallucinated, replay serves that back, which is what the Layer 2
+judge is for.
 
 ## Contributing
 

--- a/chronicle/__init__.py
+++ b/chronicle/__init__.py
@@ -16,6 +16,7 @@ from chronicle.execution_graph import ExecutionGraph
 from chronicle.redaction import apply_redactors, default_redactors, redact_secrets
 from chronicle.replay.plan import BoundaryMode, ReplayPlan
 from chronicle.session import ChronicleSession, SessionMode, get_session, reset_session
+from chronicle.wrap import instrument_langgraph, wrap
 
 __version__ = "0.2.0"
 
@@ -37,9 +38,11 @@ __all__ = [
     "boundary",
     "default_redactors",
     "get_session",
+    "instrument_langgraph",
     "record",
     "redact_secrets",
     "replay_trace",
     "reset_session",
+    "wrap",
     "wrap_llm",
 ]

--- a/chronicle/wrap.py
+++ b/chronicle/wrap.py
@@ -1,0 +1,225 @@
+"""Drop-in wrappers, so you can start recording with no decorators.
+
+- ``wrap(client)`` records every model call an OpenAI- or Anthropic-style client
+  makes. One line to adopt; in replay it returns the recorded response and makes
+  no API call.
+- ``instrument_langgraph(nodes)`` wraps every graph node as a ``@boundary`` in one
+  call, so LangGraph users do not decorate each node by hand.
+
+Both feed the same record / replay / cut-point session as ``@boundary``, so there
+is nothing new to learn: same envelopes, same ``ReplayPlan``, same ``on_crossing``.
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+from collections.abc import Callable, Mapping
+from typing import Any
+
+from chronicle.boundary import boundary
+from chronicle.envelope.schema import ActionResult, InputState
+from chronicle.session import SessionMode, get_session, sampling_params_from
+
+
+def instrument_langgraph(nodes: Mapping[str, Callable], *, kind: str = "custom") -> dict[str, Callable]:
+    """Wrap every LangGraph node as a ``@boundary`` in one call.
+
+        graph = StateGraph(State)
+        for name, fn in chronicle.instrument_langgraph({"agent": agent, "tools": tool_node}).items():
+            graph.add_node(name, fn)
+
+    Each node keeps its behavior (transparent) and gains record / stub-replay /
+    cut-point. Async nodes are supported. Use ``kind="llm"`` for nodes that call a
+    model so their envelopes capture model metadata.
+    """
+    return {name: boundary(name, kind=kind)(fn) for name, fn in nodes.items()}
+
+
+def wrap(client: Any, *, boundary_id: str = "llm") -> Any:
+    """Record every model call an OpenAI- or Anthropic-style client makes.
+
+        client = chronicle.wrap(OpenAI())
+        client.chat.completions.create(model="gpt-4o", messages=[...])  # recorded
+
+    Wraps the client's completion method in place and returns the client. It is
+    transparent in live mode (you get the real response); in replay mode it returns
+    the recorded response with attribute/index access (``resp.choices[0].message
+    .content``) and makes no API call. For a bare callable, use ``wrap_llm``.
+    """
+    target = _completion_target(client)
+    if target is None:
+        raise TypeError(
+            "chronicle.wrap expected an OpenAI-style client (.chat.completions.create) "
+            "or an Anthropic-style client (.messages.create). Use wrap_llm for other callables."
+        )
+    owner, attr, original = target
+    setattr(owner, attr, _wrap_completion(original, boundary_id))
+    return client
+
+
+def _completion_target(client: Any):
+    completions = getattr(getattr(client, "chat", None), "completions", None)
+    if completions is not None and callable(getattr(completions, "create", None)):
+        return completions, "create", completions.create
+    messages = getattr(client, "messages", None)
+    if messages is not None and callable(getattr(messages, "create", None)):
+        return messages, "create", messages.create
+    return None
+
+
+def _wrap_completion(create: Callable, boundary_id: str) -> Callable:
+    if inspect.iscoroutinefunction(create):
+        @functools.wraps(create)
+        async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+            session = get_session()
+            input_state = _input_state(kwargs)
+            if session.mode is SessionMode.REPLAY and _should_stub(session, boundary_id):
+                return _stub(session, boundary_id)
+            result = await create(*args, **kwargs)
+            _observe(session, boundary_id, input_state, result, kwargs)
+            return result
+
+        return async_wrapper
+
+    @functools.wraps(create)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        session = get_session()
+        input_state = _input_state(kwargs)
+        if session.mode is SessionMode.REPLAY and _should_stub(session, boundary_id):
+            return _stub(session, boundary_id)
+        result = create(*args, **kwargs)
+        _observe(session, boundary_id, input_state, result, kwargs)
+        return result
+
+    return wrapper
+
+
+def _should_stub(session, boundary_id: str) -> bool:
+    invocation_index = session._replay_cursor.get(boundary_id, 0) + 1
+    return session.replay_plan.should_stub(boundary_id, invocation_index)
+
+
+def _observe(session, boundary_id, input_state, response, request_kwargs):
+    """Record in LIVE, or capture as a live cut-point in REPLAY. Never mutates the
+    response; the caller always gets the real object."""
+    completion, model, usage = _extract(response)
+    if session.mode is SessionMode.REPLAY:
+        idx = session._replay_cursor.get(boundary_id, 0) + 1
+        session.capture_live_input(boundary_id, idx, input_state)
+        session.capture_live_result(boundary_id, idx, response)
+        session.next_invocation(boundary_id)
+        session._replay_cursor[boundary_id] = idx
+    else:
+        action = ActionResult(
+            completion=completion,
+            token_usage=_int_usage(usage),
+            raw_response=_raw(response),
+        )
+        session.record_envelope(
+            boundary_id, "llm", input_state, action,
+            model_version=model, sampling_params=sampling_params_from(request_kwargs),
+        )
+    if session.on_crossing is not None:
+        session.on_crossing(boundary_id, "llm", input_state, response)
+
+
+def _stub(session, boundary_id: str) -> Any:
+    envelope = session._fixture_for(boundary_id)
+    raw = envelope.action_result.raw_response
+    return _Recorded(raw) if raw is not None else envelope.action_result.completion
+
+
+def _input_state(kwargs: Mapping[str, Any]) -> InputState:
+    from chronicle.boundary import _json_safe
+
+    return InputState(
+        messages=_json_safe(list(kwargs.get("messages", []))),
+        system_prompt=kwargs.get("system") or kwargs.get("system_prompt"),
+        graph_state=_json_safe(dict(kwargs)),
+    )
+
+
+def _extract(response: Any):
+    completion = _first(
+        lambda: response.choices[0].message.content,           # OpenAI chat
+        lambda: response.content[0].text,                      # Anthropic messages
+        lambda: response["choices"][0]["message"]["content"],  # dict-shaped
+    )
+    model = getattr(response, "model", None) or _get(response, "model")
+    usage = getattr(response, "usage", None)
+    if usage is None:
+        usage = _get(response, "usage")
+    return completion, model, usage
+
+
+def _raw(response: Any) -> dict[str, Any] | None:
+    if hasattr(response, "model_dump"):
+        try:
+            return response.model_dump()
+        except Exception:
+            return None
+    if isinstance(response, Mapping):
+        return dict(response)
+    return None
+
+
+def _int_usage(usage: Any) -> dict[str, int]:
+    if usage is None:
+        return {}
+    if hasattr(usage, "model_dump"):
+        try:
+            usage = usage.model_dump()
+        except Exception:
+            return {}
+    if isinstance(usage, Mapping):
+        return {str(k): int(v) for k, v in usage.items() if isinstance(v, int) and not isinstance(v, bool)}
+    return {}
+
+
+def _first(*fns):
+    for fn in fns:
+        try:
+            value = fn()
+        except (AttributeError, IndexError, KeyError, TypeError):
+            continue
+        if value is not None:
+            return value
+    return None
+
+
+def _get(obj: Any, key: str):
+    if isinstance(obj, Mapping):
+        return obj.get(key)
+    return None
+
+
+class _Recorded:
+    """Read-only attribute and index access over a recorded response dict, so a
+    replayed call returns something shaped like the provider's response object
+    (e.g. ``resp.choices[0].message.content``)."""
+
+    __slots__ = ("_data",)
+
+    def __init__(self, data: Any) -> None:
+        object.__setattr__(self, "_data", data)
+
+    def __getattr__(self, name: str) -> Any:
+        data = object.__getattribute__(self, "_data")
+        if isinstance(data, Mapping) and name in data:
+            return _recorded(data[name])
+        raise AttributeError(name)
+
+    def __getitem__(self, key: Any) -> Any:
+        return _recorded(object.__getattribute__(self, "_data")[key])
+
+    def __repr__(self) -> str:
+        return f"Recorded({object.__getattribute__(self, '_data')!r})"
+
+
+def _recorded(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return _Recorded(value)
+    if isinstance(value, list):
+        return [_recorded(v) for v in value]
+    return value

--- a/tests/test_wrap.py
+++ b/tests/test_wrap.py
@@ -1,0 +1,114 @@
+"""chronicle.wrap(client) records with no decorators and replays without calling
+the API; chronicle.instrument_langgraph wraps nodes in one call. The fake client
+mirrors the OpenAI chat response shape (resp.choices[0].message.content)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel
+
+import chronicle
+from chronicle import ReplayPlan, reset_session
+
+
+# --- a fake OpenAI-style client (pydantic, like the real SDK responses) ----- #
+class _Message(BaseModel):
+    content: str
+
+
+class _Choice(BaseModel):
+    message: _Message
+
+
+class _Usage(BaseModel):
+    prompt_tokens: int = 3
+    completion_tokens: int = 2
+
+
+class _Resp(BaseModel):
+    model: str
+    choices: list[_Choice]
+    usage: _Usage
+
+
+class _Completions:
+    def __init__(self, calls: list) -> None:
+        self.calls = calls
+
+    def create(self, *, model, messages, **kwargs):
+        self.calls.append((model, messages, kwargs))
+        return _Resp(model=model, choices=[_Choice(message=_Message(content=f"hi from {model}"))], usage=_Usage())
+
+
+class FakeOpenAI:
+    def __init__(self) -> None:
+        self.calls: list = []
+        self.chat = type("Chat", (), {"completions": _Completions(self.calls)})()
+
+
+@pytest.mark.layer1
+def test_wrap_records_and_is_transparent():
+    client = chronicle.wrap(FakeOpenAI())
+    session = reset_session()
+    session.begin_trace("t")
+
+    resp = client.chat.completions.create(
+        model="gpt-4o", messages=[{"role": "user", "content": "hi"}], temperature=0.2
+    )
+
+    # Transparent: the caller gets the real response object.
+    assert resp.choices[0].message.content == "hi from gpt-4o"
+    env = session._recorded_envelopes[-1]
+    assert env.boundary_kind == "llm"
+    assert env.action_result.completion == "hi from gpt-4o"
+    assert env.metadata.model_version == "gpt-4o"
+    assert env.metadata.sampling_params.temperature == 0.2
+    assert env.action_result.token_usage == {"prompt_tokens": 3, "completion_tokens": 2}
+
+
+@pytest.mark.layer1
+def test_wrap_replay_returns_recorded_and_makes_no_call(tmp_path):
+    fake = FakeOpenAI()
+    client = chronicle.wrap(fake)
+
+    session = reset_session()
+    session.begin_trace("t")
+    client.chat.completions.create(model="gpt-4o", messages=[{"role": "user", "content": "hi"}])
+    trace = tmp_path / "trace"
+    session.export_trace(str(trace))
+    calls_after_record = len(fake.calls)
+
+    replay = reset_session()
+    replay.load_trace(str(trace))
+    replay.enable_replay(ReplayPlan().stub("llm", 1))
+    resp = client.chat.completions.create(model="IGNORED", messages=[{"role": "user", "content": "IGNORED"}])
+
+    # Recorded response reconstructed with attribute/index access, no new API call.
+    assert resp.choices[0].message.content == "hi from gpt-4o"
+    assert len(fake.calls) == calls_after_record
+
+
+@pytest.mark.layer1
+def test_instrument_langgraph_wraps_every_node():
+    def agent(state: dict) -> dict:
+        return {**state, "completion": "ok"}
+
+    def tools(state: dict) -> dict:
+        return {**state, "ran": True}
+
+    nodes = chronicle.instrument_langgraph({"agent": agent, "tools": tools})
+
+    session = reset_session()
+    session.begin_trace("t")
+    out = nodes["agent"]({"messages": [{"role": "user", "content": "hi"}]})
+    assert out["completion"] == "ok"  # transparent
+    assert nodes["tools"]({"messages": []})["ran"] is True
+
+    assert len(session._recorded_envelopes) == 2
+    assert {e.node_id for e in session._recorded_envelopes} == {"agent", "tools"}
+
+
+@pytest.mark.layer1
+def test_wrap_rejects_unknown_client():
+    with pytest.raises(TypeError):
+        chronicle.wrap(object())


### PR DESCRIPTION
Cuts adoption to **two lines**, on the same record / replay / cut-point session — nothing new to learn. This is the "extremely simple to use" lever.

## `chronicle.wrap(client)`
```python
client = chronicle.wrap(OpenAI())
client.chat.completions.create(model="gpt-4o", messages=[...])   # recorded + replayable
```
- **No decorators.** Records every model call an OpenAI- or Anthropic-style client makes.
- **Transparent** in live mode (you get the real response object).
- In **replay** it returns the recorded response with attribute/index access (`resp.choices[0].message.content`) and **makes no API call**.
- Sync + async; provider-agnostic best-effort extraction (completion, model, usage).

## `chronicle.instrument_langgraph(nodes)`
```python
nodes = chronicle.instrument_langgraph({"agent": agent_node, "tools": tool_node})
for name, fn in nodes.items():
    graph.add_node(name, fn)
```
Wraps every node as a `@boundary` in one call — routed through the **session**, so replay and cut-point actually work (not a separate recorder). Async nodes supported.

## Docs
Quick start now **leads with `wrap`**; the LangGraph section leads with the one-call helper (EnvelopeRecorder demoted to a `<details>`); roadmap trimmed. Folded into the 0.2.0 changelog (0.2.0 isn't released yet).

## Tests / CI
`tests/test_wrap.py` (4, incl. a real record→replay round-trip with a fake OpenAI-shaped client). **71 passed**, `ruff` clean, build + twine PASS.

## Merge note
This branch is stacked on **#19** (the ruff pin + FAQ), so its diff currently includes those. **Merge #19 first** and this PR's diff shrinks to just `wrap` + `instrument_langgraph`. (Or merge this and close #19 as superseded.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)