### PR TITLE
docs: clarify the wrap_llm README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,25 +304,29 @@ It runs after a live envelope record and a live cut-point capture, and does not
 run on stub replay. See `tests/test_cost_management_e2e.py` for an end-to-end
 ledger and budget pattern.
 
-### Wrapping LLM dispatch (`wrap_llm`)
+### `wrap_llm`: record an LLM call that is a plain function
 
-When the LLM entry point is a callable (not a decorate-able function), use
-`wrap_llm` gives the same record + `on_crossing` contract as `@boundary(..., kind="llm")`:
+Use `wrap_llm` when your model call is a **plain function you pass around** (rather
+than a named function you can decorate with `@boundary`). It gives that function the
+same record / stub-on-replay / cut-point behavior as `@boundary(..., kind="llm")`.
 
 ```python
 from chronicle import wrap_llm
 
-def complete(provider, model, messages, **kwargs):
-    ...
+def complete(model, messages, **kwargs):
+    ...                                    # your existing function that calls the model
 
-traced = wrap_llm("agent.chat", complete)
-# LIVE: executes, records envelope kind=llm, fires on_crossing
-# REPLAY stub: returns fixture without calling complete
-result = traced("openai", "gpt-4o-mini", [{"role": "user", "content": "hi"}])
+complete = wrap_llm("llm", complete)       # now it records and replays
+
+result = complete("gpt-4o", [{"role": "user", "content": "hi"}])   # use it as before
 ```
 
-Also accepts `(messages) -> result`. Pass `extract_input` / `extract_result` /
-`extract_metadata` when the signature differs.
+- **Live run:** executes `complete`, records an envelope (`kind="llm"`, with the
+  model and token usage), and fires `on_crossing`.
+- **Replay (stubbed):** returns the recorded result without calling `complete`.
+
+It reads `messages` (and `model` / `provider` if present) from the arguments
+automatically. Pass `extract_input` only if your function's signature is unusual.
 
 ## Environment variables
 


### PR DESCRIPTION
## What

Fixes the `wrap_llm` section of the README, which was unclear on `main`.

The old text had a broken sentence ("...use `wrap_llm` gives the same record + `on_crossing` contract...") and never said plainly *when* you would reach for `wrap_llm` instead of a decorator.

## After

The section now:

- Leads with the one thing that decides it: use `wrap_llm` when your model call is a **plain function you pass around** (rather than a named function you can decorate with `@boundary`).
- Spells out the two behaviors: **Live** runs and records an `llm` envelope; **Replay (stubbed)** returns the recorded result without calling the function.
- Notes that `messages` / `model` / `provider` are read from the arguments automatically, so `extract_input` is only needed for unusual signatures.

Docs-only, single file. No em/en dashes.