### PR TITLE
docs: restructure README (glossary, dropdowns), add ROADMAP, rewrite FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ deterministically from recorded incidents.
 **New here?** The [step-by-step onboarding guide](https://github.com/theagentplane/chronicle/blob/main/docs/onboarding.md)
 walks you from install to a committed regression test.
 
-**[Why](#why-chronicle) · [Architecture](#architecture) · [Install](#install) · [Quick start](#quick-start) · [Verification](#verification-layers) · [Demos](#demos) · [Comparison](#how-chronicle-compares) · [CLI](#cli) · [Roadmap](#roadmap) · [FAQ](#faq)**
+**[Why](#why-chronicle) · [Architecture](#architecture) · [Install](#install) · [Quick start](#quick-start) · [Cut-point replay](#cut-point-replay) · [Recording entry points](#recording-entry-points) · [Verification](#verification-layers) · [Demos](#demos) · [Comparison](#how-chronicle-compares) · [FAQ](#faq)**
 
 ## Why Chronicle
 
@@ -74,23 +74,29 @@ flowchart LR
 | Action / result | Structured tool calls and model completion |
 | Graph linkage | `parent_envelope_id`, `sequence`, `invocation_index` for retries |
 
+An Envelope records a boundary's **I/O**: the input that went in and the result that
+came back. It treats the boundary as a black box and does **not** capture the side
+effects that run *inside* it (files written, network calls, database writes,
+wall-clock time). Replaying a stubbed boundary returns the recorded result without
+re-running the code, which is exactly why replay is safe and deterministic.
+
 Optional OpenInference and Arize Phoenix integrations feed framework-agnostic
 tracing into this same envelope format.
 
 ## Install
 
 ```bash
-# From source (development):
-pip install -e ".[dev]"
-
 # From PyPI:
 pip install agent-chronicle
+
+# From source (development):
+pip install -e ".[dev]"
 ```
 
 ## Quick start
 
-The fastest start is to **wrap your LLM client**: no decorators, and every model
-call is recorded and replayable:
+**1. Wrap your LLM client.** No decorators. Every model call is recorded, and in
+replay it is served back from the fixture with no API call:
 
 ```python
 import chronicle
@@ -100,13 +106,18 @@ client = chronicle.wrap(OpenAI())
 client.chat.completions.create(model="gpt-4o", messages=[...])   # recorded
 ```
 
-For control over what counts as a boundary, annotate the functions that call the
-model or a tool with `@boundary`; it records in live mode and stubs from a fixture
-in replay mode. Record a run, and freeze it as a committed fixture, in a single
-block:
+> **What Chronicle captures:** the **input and the return value** at each boundary
+> (its I/O), plus metadata like model version, sampling params, and token usage.
+> Chronicle treats your boundary as a black box and does **not** capture the side
+> effects that run *inside* it (a real file delete, an API POST, a database write,
+> wall-clock time). That is what makes replay safe: a stubbed boundary returns the
+> recorded output without re-running your code, so no side effect fires again.
+
+**2. Or mark your own boundaries** with `@boundary`, for exact control over what
+counts as an LLM, tool, or routing decision. It records in live mode and stubs from
+the fixture in replay mode:
 
 ```python
-import chronicle
 from chronicle import boundary
 
 @boundary("agent", kind="llm")
@@ -116,6 +127,16 @@ def agent_plan(state: dict) -> dict:
 @boundary("delete_file", kind="tool")
 def delete_file(path: str, environment: str) -> dict:
     ...
+```
+
+`@boundary` works on `async def` too, and it is **transparent**: it never changes
+what your function returns or raises. A bare `@boundary` records the call by argument
+name, so extractors are an optional way to trim payloads, never a requirement.
+
+**3. Record a run and freeze it as a committed fixture** in one block:
+
+```python
+import chronicle
 
 with chronicle.record(
     "incident-001",
@@ -125,10 +146,21 @@ with chronicle.record(
     run_agent(...)
 ```
 
-`record()` wraps `reset_session()`; drop to the session API when you need finer
-control.
+`record()` wraps `reset_session()`; drop to the session API when you need finer control.
 
-### Cut-point replay
+### Which entry point should I record with?
+
+Pick by what you already have. All four produce the **same Envelopes**, the same
+`ReplayPlan`, and the same `on_crossing` hook, so nothing downstream changes.
+
+| You have | Use |
+|---|---|
+| An OpenAI- or Anthropic-style client | [`chronicle.wrap(client)`](#recording-entry-points) |
+| A function you can edit | `@boundary("name", kind=...)` (above) |
+| A model call that is a plain function you pass around | [`wrap_llm("name", fn)`](#recording-entry-points) |
+| LangGraph nodes | [`chronicle.instrument_langgraph(nodes)`](#recording-entry-points) |
+
+## Cut-point replay
 
 Test a fix in one boundary while the rest of the incident stays frozen. Upstream
 boundaries are stubbed from the fixture, your changed boundary runs live, and you
@@ -149,14 +181,79 @@ with chronicle.replay_trace(
     assert session.captured_result("delete_file", 1)["blocked"] is True
 ```
 
-One decorator, two behaviors: in **live** mode your function runs and its
-input/output are recorded into an Envelope; in **replay + stub** mode it does not
-run and Chronicle returns the recorded output. A cut-point is the one boundary you
-flip back to live to test new code against real upstream inputs.
+One boundary, two behaviors: in **live** mode your function runs and its I/O is
+recorded into an Envelope; in **replay + stub** mode it does not run and Chronicle
+returns the recorded output. A **cut-point** is the one boundary you flip back to
+live to test new code against real, recorded upstream inputs.
 
-`@boundary` works on `async def` too, and it is **transparent**: it never changes
-what your function returns or raises. Bare `@boundary` records the call by argument
-name, so extractors are an optional way to trim payloads, not a requirement.
+## Recording entry points
+
+`@boundary` (above) is the explicit way to mark a boundary. Three helpers cover the
+common cases where you would rather not decorate by hand. All of them record the same
+Envelopes and replay the same way.
+
+### `wrap(client)`: an OpenAI- or Anthropic-style client
+
+```python
+client = chronicle.wrap(OpenAI())
+client.chat.completions.create(model="gpt-4o", messages=[...])   # recorded
+```
+
+Wraps the client's completion method in place and returns the client. Transparent in
+live mode (you get the real response); in replay it returns the recorded response with
+attribute and index access (`resp.choices[0].message.content`) and makes no API call.
+
+### `wrap_llm(name, fn)`: a model call that is a plain function
+
+Use this when your model call is a **plain function you pass around** (not a client,
+and not a named function you can decorate):
+
+```python
+from chronicle import wrap_llm
+
+def complete(model, messages, **kwargs):
+    ...                                    # your function that calls the model
+
+complete = wrap_llm("llm", complete)       # now it records and replays
+result = complete("gpt-4o", [{"role": "user", "content": "hi"}])
+```
+
+- **Live:** runs `complete`, records an `llm` Envelope (with model and token usage).
+- **Replay (stubbed):** returns the recorded result without calling `complete`.
+
+It reads `messages` (and `model` / `provider` if present) from the arguments
+automatically. Pass `extract_input` only if the signature is unusual.
+
+### `instrument_langgraph(nodes)`: every LangGraph node at once
+
+```python
+nodes = chronicle.instrument_langgraph({"agent": agent_node, "tools": tool_node})
+for name, fn in nodes.items():
+    graph.add_node(name, fn)
+```
+
+Wraps each node as a `@boundary` in one call (async nodes supported). Use
+`kind="llm"` for nodes that call a model so their Envelopes capture model metadata.
+
+<details>
+<summary><b>Lower-level: EnvelopeRecorder</b></summary>
+
+```python
+from chronicle.envelope.capture import EnvelopeRecorder
+from chronicle.envelope.store import EnvelopeStore
+from chronicle.instrumentation import instrument_graph_nodes
+
+recorder = EnvelopeRecorder(
+    store=EnvelopeStore(".chronicle/runs/envelopes.jsonl"),
+    model_version="gpt-4o-2024-08-06",
+    build_id="deploy-abc123",
+)
+wrapped_nodes = instrument_graph_nodes(recorder, {"agent": agent_node})
+```
+
+See `examples/langgraph_demo/agent.py`.
+
+</details>
 
 ## Verification layers
 
@@ -260,39 +357,6 @@ chronicle list-fixtures                             # list committed envelope fi
 
 </details>
 
-## LangGraph integration (optional)
-
-Wrap every node in one call, so each records and replays via `@boundary` (async
-nodes supported):
-
-```python
-import chronicle
-
-nodes = chronicle.instrument_langgraph({"agent": agent_node, "tools": tool_node})
-for name, fn in nodes.items():
-    graph.add_node(name, fn)
-```
-
-<details>
-<summary><b>Lower-level: EnvelopeRecorder</b></summary>
-
-```python
-from chronicle.envelope.capture import EnvelopeRecorder
-from chronicle.envelope.store import EnvelopeStore
-from chronicle.instrumentation import instrument_graph_nodes
-
-recorder = EnvelopeRecorder(
-    store=EnvelopeStore(".chronicle/runs/envelopes.jsonl"),
-    model_version="gpt-4o-2024-08-06",
-    build_id="deploy-abc123",
-)
-wrapped_nodes = instrument_graph_nodes(recorder, {"agent": agent_node})
-```
-
-See `examples/langgraph_demo/agent.py`.
-
-</details>
-
 ## Cost and governance observers (`on_crossing`)
 
 Chronicle is the tracer; governors subscribe via `on_crossing`. External systems
@@ -306,26 +370,6 @@ session.on_crossing = my_observer  # (boundary_id, kind, input_state, result) ->
 It runs after a live envelope record and a live cut-point capture, and does not
 run on stub replay. See `tests/test_cost_management_e2e.py` for an end-to-end
 ledger and budget pattern.
-
-### Wrapping LLM dispatch (`wrap_llm`)
-
-When the LLM entry point is a callable (not a decorate-able function), use
-`wrap_llm` gives the same record + `on_crossing` contract as `@boundary(..., kind="llm")`:
-
-```python
-from chronicle import wrap_llm
-
-def complete(provider, model, messages, **kwargs):
-    ...
-
-traced = wrap_llm("agent.chat", complete)
-# LIVE: executes, records envelope kind=llm, fires on_crossing
-# REPLAY stub: returns fixture without calling complete
-result = traced("openai", "gpt-4o-mini", [{"role": "user", "content": "hi"}])
-```
-
-Also accepts `(messages) -> result`. Pass `extract_input` / `extract_result` /
-`extract_metadata` when the signature differs.
 
 ## Environment variables
 

--- a/README.md
+++ b/README.md
@@ -420,58 +420,87 @@ Ideas and priorities are welcome in [Discussions](https://github.com/theagentpla
 
 ## FAQ
 
+### Using Chronicle
+
+<details>
+<summary><b>What counts as a boundary, and how many should I add?</b></summary>
+
+A boundary is any decision point you want to be able to freeze and replay: an LLM call,
+a tool or function call, or a routing choice. You do not need to wrap everything. Start
+with the calls you would actually assert on in a test: the model call that decides an
+action, and each tool that has a real effect (a write, a payment, a delete). A boundary
+you never stub or assert on just adds an envelope, so add them where a test would look.
+</details>
+
+<details>
+<summary><b>After I record, how do I write a test?</b></summary>
+
+Open the fixture with `replay_trace(fixture, plan)` in a `with` block, run your agent,
+and assert. Two things to read from the session:
+
+- `session.captured_result(boundary_id, invocation_index)` is the return value of a
+  boundary you ran **live** (your cut-point).
+- `session.call_log()` is every boundary crossing in order, each tagged `record`,
+  `stub`, or `live`, so you can assert on control flow (which tools ran, in what order).
+
+See the Step 6 example in [Cut-point replay](#cut-point-replay).
+</details>
+
+<details>
+<summary><b>Does replay run my tools and side-effecting code?</b></summary>
+
+A **stubbed** boundary does not run at all: Chronicle returns the recorded output, so no
+file is written and no API is called. A boundary you mark `.live()` in a `ReplayPlan`
+(the cut-point) **does** run your real code, including its side effects, against the
+recorded inputs. So when you cut-point test a destructive tool, run the fixed, gated
+version or point it at a sandbox. Everything outside the cut-point stays frozen. (This
+is why an Envelope only records a boundary's I/O, never the side effects inside it.)
+</details>
+
+<details>
+<summary><b>How does replay know which recorded output to return?</b></summary>
+
+By boundary name and invocation index. The first call to `agent` in a run gets the
+first recorded `agent` envelope, the second call gets the second, and so on. That is how
+loops and retries replay correctly: each crossing is matched to the same-numbered
+crossing in the fixture.
+</details>
+
+<details>
+<summary><b>What if my code takes a different path than the recording?</b></summary>
+
+If your code calls a boundary that has no matching envelope (a brand-new boundary, or
+one more invocation than you recorded), Chronicle raises a clear `KeyError` naming the
+boundary and index. That is usually the signal you want: the run diverged from the
+recorded incident. For the part you intentionally changed, mark it `.live()` so it runs
+your new code instead of being matched against the fixture.
+</details>
+
+### Behavior and guarantees
+
 <details>
 <summary><b>Does replaying call my LLM?</b></summary>
 
-No. Layer 1 replay never calls the model; it returns the outputs recorded during the
-live run, so tests are deterministic, free, and fast. Only the optional Layer 2
-(LLM-as-judge) makes calls, and only when you ask it to.
+No. Layer 1 replay never calls the model; stubbed boundaries return the outputs recorded
+during the live run, so tests are deterministic, free, and fast. Only the optional Layer 2
+(LLM-as-judge) makes model calls, and only when you ask it to.
 </details>
 
 <details>
-<summary><b>How is this different from LangSmith, Langfuse, or Phoenix?</b></summary>
+<summary><b>Will recording add overhead or change production behavior?</b></summary>
 
-Those are tracing and eval dashboards for observing runs. Chronicle turns a recorded
-run into a deterministic, replayable regression test, and lets you re-run one boundary
-against a real incident (cut-point replay). They are complementary: trace with one,
-reproduce and test with Chronicle.
-</details>
-
-<details>
-<summary><b>Does it work with async / FastAPI?</b></summary>
-
-Yes. `async def` boundaries record, stub, and cut-point exactly like sync ones, and the
-session is per-request isolated, so concurrent requests never share a trace.
-</details>
-
-<details>
-<summary><b>Does it work with LangGraph?</b></summary>
-
-Yes. `chronicle.instrument_langgraph(nodes)` wraps every node in one call, or decorate
-nodes with `@boundary`. Auto-instrumenting a compiled graph is on the roadmap.
+`@boundary` and `wrap()` are **transparent**: they never change what your function
+returns or raises. Recording adds one wrapper call and one JSON append per boundary
+crossing, so the cost scales with how many boundaries you mark, not with anything in a
+hot loop. Enable it where you want a record; leave it off elsewhere.
 </details>
 
 <details>
 <summary><b>What about non-determinism?</b></summary>
 
-You do not force the model to be deterministic. You record the run and replay it, which
-is the only thing you actually need. (More in the
+You do not force the model to be deterministic. You record the real run and replay it,
+which is the only thing you actually need. (More in the
 [write-up](https://dev.to/tisha/your-agent-failed-in-prod-good-luck-reproducing-it-56ci).)
-</details>
-
-<details>
-<summary><b>Will recording change production behavior?</b></summary>
-
-No. `@boundary` is transparent: it never changes what your function returns or raises.
-Enable it where you want to record.
-</details>
-
-<details>
-<summary><b>What about secrets and PII?</b></summary>
-
-Turn on redaction before recording production traffic
-(`session.redactors = chronicle.default_redactors()`); secrets are masked before
-anything is stored or committed.
 </details>
 
 <details>
@@ -479,7 +508,68 @@ anything is stored or committed.
 
 It reproduces control-flow and tool-safety bugs deterministically. It does not fix a bad
 generation: if the model hallucinated, replay serves that back, which is what the Layer 2
-judge is for.
+judge is for. It is also not a tracing dashboard; see the
+[comparison](#how-chronicle-compares).
+</details>
+
+### Compatibility
+
+<details>
+<summary><b>Which LLM providers does <code>wrap()</code> support?</b></summary>
+
+`wrap()` auto-detects an OpenAI-style client (`.chat.completions.create`) and an
+Anthropic-style client (`.messages.create`). For any other SDK, or a custom dispatch
+function, use `wrap_llm(name, fn)` or mark the call with `@boundary(..., kind="llm")`.
+All three record the same envelopes and replay the same way.
+</details>
+
+<details>
+<summary><b>Does it work with async / FastAPI?</b></summary>
+
+Yes. `async def` boundaries record, stub, and cut-point exactly like sync ones, and the
+session is per-request isolated (a `ContextVar`), so concurrent requests never share a
+trace.
+</details>
+
+<details>
+<summary><b>Does it work with LangGraph?</b></summary>
+
+Yes. `chronicle.instrument_langgraph(nodes)` wraps every node in one call, or decorate
+nodes with `@boundary`. Auto-instrumenting a compiled graph (capturing routing and edge
+decisions) is on the roadmap.
+</details>
+
+<details>
+<summary><b>Does it support streaming responses?</b></summary>
+
+Not yet. Streaming and async-generator capture are on the roadmap. Today, record the
+assembled (non-streamed) response at the boundary.
+</details>
+
+<details>
+<summary><b>What Python versions are supported?</b></summary>
+
+Python 3.10 and newer.
+</details>
+
+### Operating it
+
+<details>
+<summary><b>What about secrets and PII?</b></summary>
+
+Turn on redaction before recording production traffic
+(`session.redactors = chronicle.default_redactors()`). Secrets are masked at record time,
+before anything is stored or committed, and the structure your tests assert on (roles,
+tool names, argument keys) is preserved. Add your own `(str) -> str` redactors for PII.
+</details>
+
+<details>
+<summary><b>Is it production ready?</b></summary>
+
+Chronicle is early (0.x), and the Envelope schema may still change between minor versions,
+so pin a version and re-record if you upgrade across a schema change. The
+record / replay / cut-point core is covered by the test suite and drives every demo in
+this repo.
 </details>
 
 ## Contributing


### PR DESCRIPTION
Docs-only. Makes the README skimmable and defines the jargon in one place.

## Structure
- **Key terms** dropdown up top: boundary, Envelope, trace, fixture, stub, live, cut-point, defined once.
- Reference material (CLI, `on_crossing`, env vars, `EnvelopeRecorder`, project structure) moved under an **Advanced** section of dropdowns. Each recording helper and each verification layer is its own dropdown.
- **Quick start** is three numbered steps + a "which entry point?" table; the "what gets captured (I/O, not side effects)" callout stays.
- `stub` / `live` are made explicit at the cut-point example.

## Content
- **Envelope captures I/O, not side effects** is stated in How-it-works and Quick start (this is why replay is safe).
- **FAQ rewritten** into grouped, substantive answers (boundary count, writing a test, side effects on replay, call matching, path divergence, overhead, providers, streaming, Python versions, production readiness). All verified against the code.
- **Roadmap** bullets moved to a dedicated [ROADMAP.md](ROADMAP.md) and linked, instead of living in the README.

## Cut
- Redaction/secrets was explained three times; Security section trimmed, FAQ + glossary carry the rest.

No em/en dashes. Supersedes #26 (closed).